### PR TITLE
update db schema

### DIFF
--- a/db/migrations/20210429140401_subscriptions.sql
+++ b/db/migrations/20210429140401_subscriptions.sql
@@ -12,7 +12,7 @@ create table "stripe"."subscriptions" (
   "metadata" jsonb,
   "pending_setup_intent" text,
   "pending_update" jsonb,
-  "status" subscription_status,
+  "status" "stripe"."subscription_status", 
   "application_fee_percent" double precision,
   "billing_cycle_anchor" integer,
   "billing_thresholds" jsonb,

--- a/db/migrations/20210501054139_invoices.sql
+++ b/db/migrations/20210501054139_invoices.sql
@@ -14,7 +14,7 @@ create table "stripe"."invoices" (
   "metadata" jsonb,
   "period_end" integer,
   "period_start" integer,
-  "status" invoice_status,
+  "status" "stripe"."invoice_status",
   "total" bigint,
   "account_country" text,
   "account_name" text,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, ...

## What is the current behavior?

Getting this error while running `dbmate up`. ```Error: pq: type "subscription_status" does not exist```

## What is the new behavior?

`dbmate` does not give any error currently

