### PR TITLE
fix: protect sync alternative routes

### DIFF
--- a/src/routes/sync.ts
+++ b/src/routes/sync.ts
@@ -1,22 +1,14 @@
 import { FastifyInstance } from 'fastify'
 import { syncBackfill, SyncBackfillParams } from '../lib/sync'
-import { getConfig } from '../utils/config'
-import Stripe from 'stripe'
+import { verifyApiKey } from '../utils/verifyApiKey'
 
-const config = getConfig()
+import Stripe from 'stripe'
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export default async function routes(fastify: FastifyInstance) {
   fastify.post('/sync', {
+    preHandler: [verifyApiKey],
     handler: async (request, reply) => {
-      if (!request.headers || !request.headers.authorization) {
-        return reply.code(401).send('Unauthorized')
-      }
-      const { authorization } = request.headers
-      if (authorization !== config.API_KEY) {
-        return reply.code(401).send('Unauthorized')
-      }
-
       const { created, object } =
         (request.body as {
           created?: Stripe.RangeQueryParam

--- a/src/routes/sync/daily.ts
+++ b/src/routes/sync/daily.ts
@@ -1,9 +1,11 @@
 import { FastifyInstance } from 'fastify'
 import { syncBackfill, SyncBackfillParams } from '../../lib/sync'
+import { verifyApiKey } from '../../utils/verifyApiKey'
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export default async function routes(fastify: FastifyInstance) {
   fastify.post('/daily', {
+    preHandler: [verifyApiKey],
     handler: async (request, reply) => {
       const { object } = (request.body as { object?: string }) ?? {}
       const currentTimeInSeconds = Math.floor(Date.now() / 1000)

--- a/src/routes/sync/monthly.ts
+++ b/src/routes/sync/monthly.ts
@@ -1,9 +1,11 @@
 import { FastifyInstance } from 'fastify'
 import { syncBackfill, SyncBackfillParams } from '../../lib/sync'
+import { verifyApiKey } from '../../utils/verifyApiKey'
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export default async function routes(fastify: FastifyInstance) {
   fastify.post('/monthly', {
+    preHandler: [verifyApiKey],
     handler: async (request, reply) => {
       const { object } = (request.body as { object?: string }) ?? {}
       const currentTimeInSeconds = Math.floor(Date.now() / 1000)

--- a/src/routes/sync/weekly.ts
+++ b/src/routes/sync/weekly.ts
@@ -1,9 +1,11 @@
 import { FastifyInstance } from 'fastify'
 import { syncBackfill, SyncBackfillParams } from '../../lib/sync'
+import { verifyApiKey } from '../../utils/verifyApiKey'
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export default async function routes(fastify: FastifyInstance) {
   fastify.post('/weekly', {
+    preHandler: [verifyApiKey],
     handler: async (request, reply) => {
       const { object } = (request.body as { object?: string }) ?? {}
       const currentTimeInSeconds = Math.floor(Date.now() / 1000)

--- a/src/utils/verifyApiKey.ts
+++ b/src/utils/verifyApiKey.ts
@@ -1,0 +1,19 @@
+import { FastifyReply, FastifyRequest, HookHandlerDoneFunction } from 'fastify'
+import { getConfig } from './config'
+
+const config = getConfig()
+
+export const verifyApiKey = (
+  request: FastifyRequest,
+  reply: FastifyReply,
+  done: HookHandlerDoneFunction
+) => {
+  if (!request.headers || !request.headers.authorization) {
+    return reply.code(401).send('Unauthorized')
+  }
+  const { authorization } = request.headers
+  if (authorization !== config.API_KEY) {
+    return reply.code(401).send('Unauthorized')
+  }
+  done()
+}

--- a/src/utils/verifyApiKey.ts
+++ b/src/utils/verifyApiKey.ts
@@ -7,7 +7,7 @@ export const verifyApiKey = (
   request: FastifyRequest,
   reply: FastifyReply,
   done: HookHandlerDoneFunction
-) => {
+): unknown => {
   if (!request.headers || !request.headers.authorization) {
     return reply.code(401).send('Unauthorized')
   }


### PR DESCRIPTION
Protect alternative routes to sync `daily/weekly/monthly` data