### PR TITLE
feat: sync single Stripe entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ body: {
 }
 ```
 
+### Syncing single entity
+
+To backfill/update a single entity, you can use
+
+```
+POST /sync/single/cus_12345
+```
+
+The entity type is recognized automatically, based on the prefix.
+
 ## Future ideas
 
 - Expose an "initialize" endpoint that will fetch data from Stripe and do an initial load (or perhaps `POST` a CSV to an endpoint).

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -54,6 +54,34 @@ type SyncObject =
   | 'payment_intent'
   | 'plan'
 
+export async function syncSingleEntity(stripeId: string) {
+  if (stripeId.startsWith('cus_')) {
+    return stripe.customers.retrieve(stripeId).then((it) => {
+      if (!it || it.deleted) return
+
+      return upsertCustomers([it])
+    })
+  } else if (stripeId.startsWith('in_')) {
+    return stripe.invoices.retrieve(stripeId).then((it) => upsertInvoices([it]))
+  } else if (stripeId.startsWith('price_')) {
+    return stripe.prices.retrieve(stripeId).then((it) => upsertPrices([it]))
+  } else if (stripeId.startsWith('prod_')) {
+    return stripe.products.retrieve(stripeId).then((it) => upsertProducts([it]))
+  } else if (stripeId.startsWith('sub_')) {
+    return stripe.subscriptions.retrieve(stripeId).then((it) => upsertSubscriptions([it]))
+  } else if (stripeId.startsWith('seti_')) {
+    return stripe.setupIntents.retrieve(stripeId).then((it) => upsertSetupIntents([it]))
+  } else if (stripeId.startsWith('pm_')) {
+    return stripe.paymentMethods.retrieve(stripeId).then((it) => upsertPaymentMethods([it]))
+  } else if (stripeId.startsWith('dp_') || stripeId.startsWith('du_')) {
+    return stripe.disputes.retrieve(stripeId).then((it) => upsertDisputes([it]))
+  } else if (stripeId.startsWith('ch_')) {
+    return stripe.charges.retrieve(stripeId).then((it) => upsertCharges([it]))
+  } else if (stripeId.startsWith('pi_')) {
+    return stripe.paymentIntents.retrieve(stripeId).then((it) => upsertPaymentIntents([it]))
+  }
+}
+
 export async function syncBackfill(params?: SyncBackfillParams): Promise<SyncBackfill> {
   const { created, object } = params ?? {}
   let products,

--- a/src/routes/sync.ts
+++ b/src/routes/sync.ts
@@ -1,5 +1,5 @@
 import { FastifyInstance } from 'fastify'
-import { syncBackfill, SyncBackfillParams } from '../lib/sync'
+import { syncBackfill, SyncBackfillParams, syncSingleEntity } from '../lib/sync'
 import { verifyApiKey } from '../utils/verifyApiKey'
 
 import Stripe from 'stripe'
@@ -20,6 +20,33 @@ export default async function routes(fastify: FastifyInstance) {
         statusCode: 200,
         ts: Date.now(),
         ...result,
+      })
+    },
+  })
+
+  fastify.post<{
+    Params: {
+      stripeId: string
+    }
+  }>('/sync/single/:stripeId', {
+    preHandler: [verifyApiKey],
+    schema: {
+      params: {
+        type: 'object',
+        properties: {
+          stripeId: { type: 'string' },
+        },
+      },
+    },
+    handler: async (request, reply) => {
+      const { stripeId } = request.params
+
+      const result = await syncSingleEntity(stripeId)
+
+      return reply.send({
+        statusCode: 200,
+        ts: Date.now(),
+        data: result,
       })
     },
   })

--- a/src/routes/sync/daily.ts
+++ b/src/routes/sync/daily.ts
@@ -15,11 +15,11 @@ export default async function routes(fastify: FastifyInstance) {
         object: object ?? 'all',
       } as SyncBackfillParams
 
-      const result = await syncBackfill(params)
+      await syncBackfill(params)
+
       return reply.send({
         statusCode: 200,
         ts: Date.now(),
-        ...result,
       })
     },
   })


### PR DESCRIPTION
I realized some of our older Stripe entities (2021) are outdated, so would be great to have a way to refresh the data, as we don’t have a way to trigger changes on Stripe (i.e. cancelled subscriptions)