### PR TITLE
build(docker): move building project to build stage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,7 @@ db
 test
 dist
 node_modules
+.tours
+.vscode
+docker
+docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,13 @@ FROM node:18-alpine
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci 
+COPY . /app
+RUN npm run build 
+RUN npm prune --production
 
 ## Build step complete, copy to working image
 FROM node:18-alpine
 WORKDIR /app
+ENV NODE_ENV=production
 COPY --from=0 /app .
-COPY . .
-RUN npm run build 
 CMD ["npm", "start"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "fastify": "^4.17.0",
         "pg": "^8.11.0",
         "pg-node-migrations": "0.0.8",
+        "pino": "^8.14.1",
         "stripe": "^8.222.0",
         "yesql": "^6.1.0"
       },
@@ -31,7 +32,6 @@
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-prettier": "^4.2.1",
         "jest": "^29.5.0",
-        "pino": "^8.14.1",
         "prettier": "^2.8.8",
         "ts-jest": "^29.1.0",
         "ts-node-dev": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "pg": "^8.11.0",
     "pg-node-migrations": "0.0.8",
     "stripe": "^8.222.0",
-    "yesql": "^6.1.0"
+    "yesql": "^6.1.0",
+    "pino": "^8.14.1"
   },
   "devDependencies": {
     "@types/jest": "^29.5.1",
@@ -49,7 +50,6 @@
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^4.2.1",
     "jest": "^29.5.0",
-    "pino": "^8.14.1",
     "prettier": "^2.8.8",
     "ts-jest": "^29.1.0",
     "ts-node-dev": "^2.0.0",


### PR DESCRIPTION
Moves building the project to the docker build stage and prunes the non-production dependencies.

Shaves off around a third of the docker image size (297 MB => 200 MB)