### PR TITLE
fix: semantic version release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         id: semantic-release
         uses: cycjimmy/semantic-release-action@v3
         with:
-          semantic_version: 21
+          semantic_version: 19
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Semantic version v20 contains a rewrite to ESM, so release job fails.