### PR TITLE
fix: use null for missing values

### DIFF
--- a/src/lib/database_utils.ts
+++ b/src/lib/database_utils.ts
@@ -19,7 +19,7 @@ export const upsertMany = async <
   entries.forEach((entry) => {
     // Inject the values
     const cleansed = cleanseArrayField(entry)
-    const prepared = sql(upsertSql(entry))(cleansed)
+    const prepared = sql(upsertSql(entry), { useNullForMissing: true })(cleansed)
 
     queries.push(query(prepared.text, prepared.values))
   })
@@ -34,7 +34,7 @@ export const findMissingEntries = async (table: string, ids: string[]): Promise<
   if (!ids.length) return []
 
   const prepared = sql(`
-    select id from "${config.SCHEMA}"."${table}" 
+    select id from "${config.SCHEMA}"."${table}"
     where id=any(:ids::text[]);
     `)({ ids })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

uses `null` for missing values. sometimes, the web hook data does not include all data that the schema expects. by default, yesql throws (#29). right now, this is blocking us from using the sync engine since syncing customer data fails. 

## What is the current behavior?

an error is thrown if there are missing properties. 

## What is the new behavior?

`null` is used. 

## Additional context

fixes #29 