### PR TITLE
feat: add support for additional ssl db params

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,6 @@
 NODE_ENV=production
 DATABASE_URL=postgres://postgres:postgres@host:5432/postgres?sslmode=disable&search_path=stripe
+DATABASE_SSL_REJECT_UNAUTHORIZED=true
 STRIPE_SECRET_KEY=sk_test_
 STRIPE_WEBHOOK_SECRET=whsec_
 SCHEMA=stripe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: supabase/stripe-sync-engine:latest,supabase/stripe-sync-engine:v${{ needs.release.outputs.new-release-version }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/stripe-sync-engine:latest,${{ secrets.DOCKERHUB_USERNAME }}/stripe-sync-engine:v${{ needs.release.outputs.new-release-version }}
           platforms: linux/amd64,linux/arm64
 
       - name: Image digest

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -166,7 +166,7 @@ export default async function routes(fastify: FastifyInstance) {
         }
 
         default:
-          throw new Error('Unhandled webhook event')
+          return reply.send({ received: true, handled: false })
       }
 
       return reply.send({ received: true })

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,7 +4,7 @@ import { runMigrations } from './utils/migrate'
 import { createServer } from './app'
 import pino from 'pino'
 import { getConfig } from './utils/config'
-import { Client } from 'pg'
+import { Client, ClientConfig } from 'pg'
 
 const config = getConfig()
 
@@ -28,9 +28,12 @@ const main = async () => {
   const port = process.env.PORT || 8080
 
   // Init DB
-  const dbConfig = {
+  const dbConfig: ClientConfig = {
     connectionString: config.DATABASE_URL,
     connectionTimeoutMillis: 10_000,
+    ssl: {
+      rejectUnauthorized: config.DATABASE_SSL_REJECT_UNAUTHORIZED,
+    },
   }
   const client = new Client(dbConfig)
 

--- a/src/utils/PostgresConnection.ts
+++ b/src/utils/PostgresConnection.ts
@@ -2,7 +2,12 @@ import { Pool, QueryResult } from 'pg'
 import { getConfig } from './config'
 
 const config = getConfig()
-const pool = new Pool({ connectionString: config.DATABASE_URL })
+const pool = new Pool({
+  connectionString: config.DATABASE_URL,
+  ssl: {
+    rejectUnauthorized: config.DATABASE_SSL_REJECT_UNAUTHORIZED,
+  },
+})
 
 /**
  * Use this inside a route/file

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -2,6 +2,7 @@ import dotenv from 'dotenv'
 
 type configType = {
   DATABASE_URL: string
+  DATABASE_SSL_REJECT_UNAUTHORIZED: boolean
   NODE_ENV: string
   SCHEMA: string
   STRIPE_SECRET_KEY: string
@@ -9,9 +10,11 @@ type configType = {
   API_KEY: string
 }
 
-function getConfigFromEnv(key: string): string {
+function getConfigFromEnv(key: string, defaultValue?: string): string {
   const value = process.env[key]
   if (!value) {
+    if (defaultValue) return defaultValue
+
     throw new Error(`${key} is undefined`)
   }
   return value
@@ -22,6 +25,8 @@ export function getConfig(): configType {
 
   return {
     DATABASE_URL: getConfigFromEnv('DATABASE_URL'),
+    DATABASE_SSL_REJECT_UNAUTHORIZED:
+      getConfigFromEnv('DATABASE_SSL_REJECT_UNAUTHORIZED', String(true)) === String(true),
     SCHEMA: getConfigFromEnv('SCHEMA'),
     NODE_ENV: getConfigFromEnv('NODE_ENV'),
     STRIPE_SECRET_KEY: getConfigFromEnv('STRIPE_SECRET_KEY'),


### PR DESCRIPTION
## What kind of change does this PR introduce?
Adds a new env variable for adjusting database SSL config.

## What is the current behavior?
Throws error for database using self signed certificate

## What is the new behavior?
Make `ssl.rejectUnauthorized` configurable via the env variable.

## Additional context

![image](https://github.com/supabase/stripe-sync-engine/assets/55424194/8a77e1e1-45cf-42f5-96f0-f6c151a9f88a)

