### PR TITLE
fix: deno & release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,4 +107,4 @@ jobs:
           pnpm pack
           npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/sync-engine/src/stripeSync.ts
+++ b/packages/sync-engine/src/stripeSync.ts
@@ -60,7 +60,7 @@ export class StripeSync {
   }
 
   async processWebhook(payload: Buffer | string, signature: string | undefined) {
-    const event = this.stripe.webhooks.constructEvent(
+    const event = await this.stripe.webhooks.constructEventAsync(
       payload,
       signature!,
       this.config.stripeWebhookSecret


### PR DESCRIPTION
Deno fails with SubtleCryptoProvider - using the async method works for both Deno and Node - verified in Supabase Edge Function
