### PR TITLE
Soft delete on customer

### DIFF
--- a/packages/sync-engine/src/stripeSync.ts
+++ b/packages/sync-engine/src/stripeSync.ts
@@ -86,7 +86,11 @@ export class StripeSync {
         break
       }
       case 'customer.deleted': {
-        const customer = { ...event.data.object, deleted: true }
+        const customer: Stripe.DeletedCustomer = {
+          id: event.data.object.id,
+          object: 'customer',
+          deleted: true,
+        }
 
         this.config.logger?.info(
           `Received webhook ${event.id}: ${event.type} for customer ${customer.id}`


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

[Deleting sync](https://github.com/supabase/stripe-sync-engine/issues/171)

## What is the new behavior?

"deleted" column on customer table is set to TRUE when webhook event "customer"."deleted".
