### PR TITLE
chore: add upsert timestamp protection

### DIFF
--- a/packages/sync-engine/src/database/migrations/0033_add_last_synced_at.sql
+++ b/packages/sync-engine/src/database/migrations/0033_add_last_synced_at.sql
@@ -1,0 +1,85 @@
+-- Add last_synced_at column to all Stripe tables for tracking sync status
+
+-- Charges
+alter table "stripe"."charges"
+add column IF NOT EXISTS "last_synced_at" timestamptz;
+
+-- Coupons
+alter table "stripe"."coupons"
+add column IF NOT EXISTS "last_synced_at" timestamptz;
+
+-- Credit Notes
+alter table "stripe"."credit_notes"
+add column IF NOT EXISTS "last_synced_at" timestamptz;
+
+-- Customers
+alter table "stripe"."customers"
+add column IF NOT EXISTS "last_synced_at" timestamptz;
+
+-- Disputes
+alter table "stripe"."disputes"
+add column IF NOT EXISTS "last_synced_at" timestamptz;
+
+-- Early Fraud Warnings
+alter table "stripe"."early_fraud_warnings"
+add column IF NOT EXISTS "last_synced_at" timestamptz;
+
+-- Events
+alter table "stripe"."events"
+add column IF NOT EXISTS "last_synced_at" timestamptz;
+
+-- Invoices
+alter table "stripe"."invoices"
+add column IF NOT EXISTS "last_synced_at" timestamptz;
+
+-- Payment Intents
+alter table "stripe"."payment_intents"
+add column IF NOT EXISTS "last_synced_at" timestamptz;
+
+-- Payment Methods
+alter table "stripe"."payment_methods"
+add column IF NOT EXISTS "last_synced_at" timestamptz;
+
+-- Payouts
+alter table "stripe"."payouts"
+add column IF NOT EXISTS "last_synced_at" timestamptz;
+
+-- Plans
+alter table "stripe"."plans"
+add column IF NOT EXISTS "last_synced_at" timestamptz;
+
+-- Prices
+alter table "stripe"."prices"
+add column IF NOT EXISTS "last_synced_at" timestamptz;
+
+-- Products
+alter table "stripe"."products"
+add column IF NOT EXISTS "last_synced_at" timestamptz;
+
+-- Refunds
+alter table "stripe"."refunds"
+add column IF NOT EXISTS "last_synced_at" timestamptz;
+
+-- Reviews
+alter table "stripe"."reviews"
+add column IF NOT EXISTS "last_synced_at" timestamptz;
+
+-- Setup Intents
+alter table "stripe"."setup_intents"
+add column IF NOT EXISTS "last_synced_at" timestamptz;
+
+-- Subscription Items
+alter table "stripe"."subscription_items"
+add column IF NOT EXISTS "last_synced_at" timestamptz;
+
+-- Subscription Schedules
+alter table "stripe"."subscription_schedules"
+add column IF NOT EXISTS "last_synced_at" timestamptz;
+
+-- Subscriptions
+alter table "stripe"."subscriptions"
+add column IF NOT EXISTS "last_synced_at" timestamptz;
+
+-- Tax IDs
+alter table "stripe"."tax_ids"
+add column IF NOT EXISTS "last_synced_at" timestamptz;

--- a/packages/sync-engine/src/database/migrations/0034_remove_foreign_keys.sql
+++ b/packages/sync-engine/src/database/migrations/0034_remove_foreign_keys.sql
@@ -1,0 +1,13 @@
+-- Remove all foreign key constraints
+
+ALTER TABLE "stripe"."subscriptions" DROP CONSTRAINT IF EXISTS "subscriptions_customer_fkey";
+
+ALTER TABLE "stripe"."prices" DROP CONSTRAINT IF EXISTS "prices_product_fkey";
+
+ALTER TABLE "stripe"."invoices" DROP CONSTRAINT IF EXISTS "invoices_customer_fkey";
+
+ALTER TABLE "stripe"."invoices" DROP CONSTRAINT IF EXISTS "invoices_subscription_fkey";
+
+ALTER TABLE "stripe"."subscription_items" DROP CONSTRAINT IF EXISTS "subscription_items_price_fkey";
+
+ALTER TABLE "stripe"."subscription_items" DROP CONSTRAINT IF EXISTS "subscription_items_subscription_fkey";

--- a/packages/sync-engine/src/index.ts
+++ b/packages/sync-engine/src/index.ts
@@ -3,3 +3,4 @@ export { StripeSync } from './stripeSync'
 export type * from './types'
 
 export { runMigrations } from './database/migrate'
+export { PostgresClient } from './database/postgres'

--- a/packages/sync-engine/src/stripeSync.ts
+++ b/packages/sync-engine/src/stripeSync.ts
@@ -66,6 +66,8 @@ export class StripeSync {
       this.config.stripeWebhookSecret
     )
 
+    const syncTimestamp = new Date(event.created * 1000).toISOString()
+
     switch (event.type) {
       case 'charge.captured':
       case 'charge.expired':
@@ -82,7 +84,7 @@ export class StripeSync {
           `Received webhook ${event.id}: ${event.type} for charge ${charge.id}`
         )
 
-        await this.upsertCharges([charge])
+        await this.upsertCharges([charge], false, syncTimestamp)
         break
       }
       case 'customer.deleted': {
@@ -96,7 +98,7 @@ export class StripeSync {
           `Received webhook ${event.id}: ${event.type} for customer ${customer.id}`
         )
 
-        await this.upsertCustomers([customer])
+        await this.upsertCustomers([customer], syncTimestamp)
         break
       }
       case 'customer.created':
@@ -110,7 +112,7 @@ export class StripeSync {
           `Received webhook ${event.id}: ${event.type} for customer ${customer.id}`
         )
 
-        await this.upsertCustomers([customer])
+        await this.upsertCustomers([customer], syncTimestamp)
         break
       }
       case 'customer.subscription.created':
@@ -130,7 +132,7 @@ export class StripeSync {
           `Received webhook ${event.id}: ${event.type} for subscription ${subscription.id}`
         )
 
-        await this.upsertSubscriptions([subscription])
+        await this.upsertSubscriptions([subscription], false, syncTimestamp)
         break
       }
       case 'customer.tax_id.updated':
@@ -143,7 +145,7 @@ export class StripeSync {
           `Received webhook ${event.id}: ${event.type} for taxId ${taxId.id}`
         )
 
-        await this.upsertTaxIds([taxId])
+        await this.upsertTaxIds([taxId], false, syncTimestamp)
         break
       }
       case 'customer.tax_id.deleted': {
@@ -178,7 +180,7 @@ export class StripeSync {
           `Received webhook ${event.id}: ${event.type} for invoice ${invoice.id}`
         )
 
-        await this.upsertInvoices([invoice])
+        await this.upsertInvoices([invoice], false, syncTimestamp)
         break
       }
       case 'product.created':
@@ -193,7 +195,7 @@ export class StripeSync {
             `Received webhook ${event.id}: ${event.type} for product ${product.id}`
           )
 
-          await this.upsertProducts([product])
+          await this.upsertProducts([product], syncTimestamp)
         } catch (err) {
           if (err instanceof Stripe.errors.StripeAPIError && err.code === 'resource_missing') {
             await this.deleteProduct(event.data.object.id)
@@ -225,7 +227,7 @@ export class StripeSync {
             `Received webhook ${event.id}: ${event.type} for price ${price.id}`
           )
 
-          await this.upsertPrices([price])
+          await this.upsertPrices([price], false, syncTimestamp)
         } catch (err) {
           if (err instanceof Stripe.errors.StripeAPIError && err.code === 'resource_missing') {
             await this.deletePrice(event.data.object.id)
@@ -257,7 +259,7 @@ export class StripeSync {
             `Received webhook ${event.id}: ${event.type} for plan ${plan.id}`
           )
 
-          await this.upsertPlans([plan])
+          await this.upsertPlans([plan], false, syncTimestamp)
         } catch (err) {
           if (err instanceof Stripe.errors.StripeAPIError && err.code === 'resource_missing') {
             await this.deletePlan(event.data.object.id)
@@ -290,7 +292,7 @@ export class StripeSync {
           `Received webhook ${event.id}: ${event.type} for setupIntent ${setupIntent.id}`
         )
 
-        await this.upsertSetupIntents([setupIntent])
+        await this.upsertSetupIntents([setupIntent], false, syncTimestamp)
         break
       }
       case 'subscription_schedule.aborted':
@@ -309,7 +311,7 @@ export class StripeSync {
           `Received webhook ${event.id}: ${event.type} for subscriptionSchedule ${subscriptionSchedule.id}`
         )
 
-        await this.upsertSubscriptionSchedules([subscriptionSchedule])
+        await this.upsertSubscriptionSchedules([subscriptionSchedule], false, syncTimestamp)
         break
       }
       case 'payment_method.attached':
@@ -325,7 +327,7 @@ export class StripeSync {
           `Received webhook ${event.id}: ${event.type} for paymentMethod ${paymentMethod.id}`
         )
 
-        await this.upsertPaymentMethods([paymentMethod])
+        await this.upsertPaymentMethods([paymentMethod], false, syncTimestamp)
         break
       }
       case 'charge.dispute.created':
@@ -342,7 +344,7 @@ export class StripeSync {
           `Received webhook ${event.id}: ${event.type} for dispute ${dispute.id}`
         )
 
-        await this.upsertDisputes([dispute])
+        await this.upsertDisputes([dispute], false, syncTimestamp)
         break
       }
       case 'payment_intent.amount_capturable_updated':
@@ -362,7 +364,7 @@ export class StripeSync {
           `Received webhook ${event.id}: ${event.type} for paymentIntent ${paymentIntent.id}`
         )
 
-        await this.upsertPaymentIntents([paymentIntent])
+        await this.upsertPaymentIntents([paymentIntent], false, syncTimestamp)
         break
       }
 
@@ -378,7 +380,7 @@ export class StripeSync {
           `Received webhook ${event.id}: ${event.type} for creditNote ${creditNote.id}`
         )
 
-        await this.upsertCreditNotes([creditNote])
+        await this.upsertCreditNotes([creditNote], false, syncTimestamp)
         break
       }
 
@@ -393,7 +395,7 @@ export class StripeSync {
           `Received webhook ${event.id}: ${event.type} for earlyFraudWarning ${earlyFraudWarning.id}`
         )
 
-        await this.upsertEarlyFraudWarning([earlyFraudWarning])
+        await this.upsertEarlyFraudWarning([earlyFraudWarning], false, syncTimestamp)
 
         break
       }
@@ -410,7 +412,7 @@ export class StripeSync {
           `Received webhook ${event.id}: ${event.type} for refund ${refund.id}`
         )
 
-        await this.upsertRefunds([refund])
+        await this.upsertRefunds([refund], false, syncTimestamp)
         break
       }
 
@@ -424,7 +426,7 @@ export class StripeSync {
           `Received webhook ${event.id}: ${event.type} for review ${review.id}`
         )
 
-        await this.upsertReviews([review])
+        await this.upsertReviews([review], false, syncTimestamp)
 
         break
       }
@@ -846,7 +848,8 @@ export class StripeSync {
 
   private async upsertCharges(
     charges: Stripe.Charge[],
-    backfillRelatedEntities?: boolean
+    backfillRelatedEntities?: boolean,
+    syncTimestamp?: string
   ): Promise<Stripe.Charge[]> {
     if (backfillRelatedEntities ?? this.config.backfillRelatedEntities) {
       await Promise.all([
@@ -859,7 +862,12 @@ export class StripeSync {
       this.stripe.refunds.list({ charge: id, limit: 100 })
     )
 
-    return this.postgresClient.upsertMany(charges, 'charges', chargeSchema)
+    return this.postgresClient.upsertManyWithTimestampProtection(
+      charges,
+      'charges',
+      chargeSchema,
+      syncTimestamp
+    )
   }
 
   private async backfillCharges(chargeIds: string[]) {
@@ -883,7 +891,8 @@ export class StripeSync {
 
   private async upsertCreditNotes(
     creditNotes: Stripe.CreditNote[],
-    backfillRelatedEntities?: boolean
+    backfillRelatedEntities?: boolean,
+    syncTimestamp?: string
   ): Promise<Stripe.CreditNote[]> {
     if (backfillRelatedEntities ?? this.config.backfillRelatedEntities) {
       await Promise.all([
@@ -896,12 +905,18 @@ export class StripeSync {
       this.stripe.creditNotes.listLineItems(id, { limit: 100 })
     )
 
-    return this.postgresClient.upsertMany(creditNotes, 'credit_notes', creditNoteSchema)
+    return this.postgresClient.upsertManyWithTimestampProtection(
+      creditNotes,
+      'credit_notes',
+      creditNoteSchema,
+      syncTimestamp
+    )
   }
 
   async upsertEarlyFraudWarning(
     earlyFraudWarnings: Stripe.Radar.EarlyFraudWarning[],
-    backfillRelatedEntities?: boolean
+    backfillRelatedEntities?: boolean,
+    syncTimestamp?: string
   ): Promise<Stripe.Radar.EarlyFraudWarning[]> {
     if (backfillRelatedEntities ?? this.config.backfillRelatedEntities) {
       await Promise.all([
@@ -910,16 +925,18 @@ export class StripeSync {
       ])
     }
 
-    return this.postgresClient.upsertMany(
+    return this.postgresClient.upsertManyWithTimestampProtection(
       earlyFraudWarnings,
       'early_fraud_warnings',
-      earlyFraudWarningSchema
+      earlyFraudWarningSchema,
+      syncTimestamp
     )
   }
 
   async upsertRefunds(
     refunds: Stripe.Refund[],
-    backfillRelatedEntities?: boolean
+    backfillRelatedEntities?: boolean,
+    syncTimestamp?: string
   ): Promise<Stripe.Refund[]> {
     if (backfillRelatedEntities ?? this.config.backfillRelatedEntities) {
       await Promise.all([
@@ -928,12 +945,18 @@ export class StripeSync {
       ])
     }
 
-    return this.postgresClient.upsertMany(refunds, 'refunds', refundSchema)
+    return this.postgresClient.upsertManyWithTimestampProtection(
+      refunds,
+      'refunds',
+      refundSchema,
+      syncTimestamp
+    )
   }
 
   async upsertReviews(
     reviews: Stripe.Review[],
-    backfillRelatedEntities?: boolean
+    backfillRelatedEntities?: boolean,
+    syncTimestamp?: string
   ): Promise<Stripe.Review[]> {
     if (backfillRelatedEntities ?? this.config.backfillRelatedEntities) {
       await Promise.all([
@@ -942,17 +965,33 @@ export class StripeSync {
       ])
     }
 
-    return this.postgresClient.upsertMany(reviews, 'reviews', reviewSchema)
+    return this.postgresClient.upsertManyWithTimestampProtection(
+      reviews,
+      'reviews',
+      reviewSchema,
+      syncTimestamp
+    )
   }
 
   async upsertCustomers(
-    customers: (Stripe.Customer | Stripe.DeletedCustomer)[]
+    customers: (Stripe.Customer | Stripe.DeletedCustomer)[],
+    syncTimestamp?: string
   ): Promise<(Stripe.Customer | Stripe.DeletedCustomer)[]> {
     const deletedCustomers = customers.filter((customer) => customer.deleted)
     const nonDeletedCustomers = customers.filter((customer) => !customer.deleted)
 
-    await this.postgresClient.upsertMany(nonDeletedCustomers, 'customers', customerSchema)
-    await this.postgresClient.upsertMany(deletedCustomers, 'customers', customerDeletedSchema)
+    await this.postgresClient.upsertManyWithTimestampProtection(
+      nonDeletedCustomers,
+      'customers',
+      customerSchema,
+      syncTimestamp
+    )
+    await this.postgresClient.upsertManyWithTimestampProtection(
+      deletedCustomers,
+      'customers',
+      customerDeletedSchema,
+      syncTimestamp
+    )
 
     return customers
   }
@@ -970,18 +1009,25 @@ export class StripeSync {
 
   async upsertDisputes(
     disputes: Stripe.Dispute[],
-    backfillRelatedEntities?: boolean
+    backfillRelatedEntities?: boolean,
+    syncTimestamp?: string
   ): Promise<Stripe.Dispute[]> {
     if (backfillRelatedEntities ?? this.config.backfillRelatedEntities) {
       await this.backfillCharges(getUniqueIds(disputes, 'charge'))
     }
 
-    return this.postgresClient.upsertMany(disputes, 'disputes', disputeSchema)
+    return this.postgresClient.upsertManyWithTimestampProtection(
+      disputes,
+      'disputes',
+      disputeSchema,
+      syncTimestamp
+    )
   }
 
   async upsertInvoices(
     invoices: Stripe.Invoice[],
-    backfillRelatedEntities?: boolean
+    backfillRelatedEntities?: boolean,
+    syncTimestamp?: string
   ): Promise<Stripe.Invoice[]> {
     if (backfillRelatedEntities ?? this.config.backfillRelatedEntities) {
       await Promise.all([
@@ -994,7 +1040,12 @@ export class StripeSync {
       this.stripe.invoices.listLineItems(id, { limit: 100 })
     )
 
-    return this.postgresClient.upsertMany(invoices, 'invoices', invoiceSchema)
+    return this.postgresClient.upsertManyWithTimestampProtection(
+      invoices,
+      'invoices',
+      invoiceSchema,
+      syncTimestamp
+    )
   }
 
   backfillInvoices = async (invoiceIds: string[]) => {
@@ -1006,13 +1057,19 @@ export class StripeSync {
 
   async upsertPlans(
     plans: Stripe.Plan[],
-    backfillRelatedEntities?: boolean
+    backfillRelatedEntities?: boolean,
+    syncTimestamp?: string
   ): Promise<Stripe.Plan[]> {
     if (backfillRelatedEntities ?? this.config.backfillRelatedEntities) {
       await this.backfillProducts(getUniqueIds(plans, 'product'))
     }
 
-    return this.postgresClient.upsertMany(plans, 'plans', planSchema)
+    return this.postgresClient.upsertManyWithTimestampProtection(
+      plans,
+      'plans',
+      planSchema,
+      syncTimestamp
+    )
   }
 
   async deletePlan(id: string): Promise<boolean> {
@@ -1021,21 +1078,35 @@ export class StripeSync {
 
   async upsertPrices(
     prices: Stripe.Price[],
-    backfillRelatedEntities?: boolean
+    backfillRelatedEntities?: boolean,
+    syncTimestamp?: string
   ): Promise<Stripe.Price[]> {
     if (backfillRelatedEntities ?? this.config.backfillRelatedEntities) {
       await this.backfillProducts(getUniqueIds(prices, 'product'))
     }
 
-    return this.postgresClient.upsertMany(prices, 'prices', priceSchema)
+    return this.postgresClient.upsertManyWithTimestampProtection(
+      prices,
+      'prices',
+      priceSchema,
+      syncTimestamp
+    )
   }
 
   async deletePrice(id: string): Promise<boolean> {
     return this.postgresClient.delete('prices', id)
   }
 
-  async upsertProducts(products: Stripe.Product[]): Promise<Stripe.Product[]> {
-    return this.postgresClient.upsertMany(products, 'products', productSchema)
+  async upsertProducts(
+    products: Stripe.Product[],
+    syncTimestamp?: string
+  ): Promise<Stripe.Product[]> {
+    return this.postgresClient.upsertManyWithTimestampProtection(
+      products,
+      'products',
+      productSchema,
+      syncTimestamp
+    )
   }
 
   async deleteProduct(id: string): Promise<boolean> {
@@ -1052,7 +1123,8 @@ export class StripeSync {
 
   async upsertPaymentIntents(
     paymentIntents: Stripe.PaymentIntent[],
-    backfillRelatedEntities?: boolean
+    backfillRelatedEntities?: boolean,
+    syncTimestamp?: string
   ): Promise<Stripe.PaymentIntent[]> {
     if (backfillRelatedEntities ?? this.config.backfillRelatedEntities) {
       await Promise.all([
@@ -1061,47 +1133,73 @@ export class StripeSync {
       ])
     }
 
-    return this.postgresClient.upsertMany(paymentIntents, 'payment_intents', paymentIntentSchema)
+    return this.postgresClient.upsertManyWithTimestampProtection(
+      paymentIntents,
+      'payment_intents',
+      paymentIntentSchema,
+      syncTimestamp
+    )
   }
 
   async upsertPaymentMethods(
     paymentMethods: Stripe.PaymentMethod[],
-    backfillRelatedEntities: boolean = false
+    backfillRelatedEntities: boolean = false,
+    syncTimestamp?: string
   ): Promise<Stripe.PaymentMethod[]> {
     if (backfillRelatedEntities ?? this.config.backfillRelatedEntities) {
       await this.backfillCustomers(getUniqueIds(paymentMethods, 'customer'))
     }
 
-    return this.postgresClient.upsertMany(paymentMethods, 'payment_methods', paymentMethodsSchema)
+    return this.postgresClient.upsertManyWithTimestampProtection(
+      paymentMethods,
+      'payment_methods',
+      paymentMethodsSchema,
+      syncTimestamp
+    )
   }
 
   async upsertSetupIntents(
     setupIntents: Stripe.SetupIntent[],
-    backfillRelatedEntities?: boolean
+    backfillRelatedEntities?: boolean,
+    syncTimestamp?: string
   ): Promise<Stripe.SetupIntent[]> {
     if (backfillRelatedEntities ?? this.config.backfillRelatedEntities) {
       await this.backfillCustomers(getUniqueIds(setupIntents, 'customer'))
     }
 
-    return this.postgresClient.upsertMany(setupIntents, 'setup_intents', setupIntentsSchema)
+    return this.postgresClient.upsertManyWithTimestampProtection(
+      setupIntents,
+      'setup_intents',
+      setupIntentsSchema,
+      syncTimestamp
+    )
   }
 
   async upsertTaxIds(
     taxIds: Stripe.TaxId[],
-    backfillRelatedEntities?: boolean
+    backfillRelatedEntities?: boolean,
+    syncTimestamp?: string
   ): Promise<Stripe.TaxId[]> {
     if (backfillRelatedEntities ?? this.config.backfillRelatedEntities) {
       await this.backfillCustomers(getUniqueIds(taxIds, 'customer'))
     }
 
-    return this.postgresClient.upsertMany(taxIds, 'tax_ids', taxIdSchema)
+    return this.postgresClient.upsertManyWithTimestampProtection(
+      taxIds,
+      'tax_ids',
+      taxIdSchema,
+      syncTimestamp
+    )
   }
 
   async deleteTaxId(id: string): Promise<boolean> {
     return this.postgresClient.delete('tax_ids', id)
   }
 
-  async upsertSubscriptionItems(subscriptionItems: Stripe.SubscriptionItem[]) {
+  async upsertSubscriptionItems(
+    subscriptionItems: Stripe.SubscriptionItem[],
+    syncTimestamp?: string
+  ) {
     const modifiedSubscriptionItems = subscriptionItems.map((subscriptionItem) => {
       // Modify price object to string id; reference prices table
       const priceId = subscriptionItem.price.id.toString()
@@ -1117,10 +1215,11 @@ export class StripeSync {
       }
     })
 
-    await this.postgresClient.upsertMany(
+    await this.postgresClient.upsertManyWithTimestampProtection(
       modifiedSubscriptionItems,
       'subscription_items',
-      subscriptionItemSchema
+      subscriptionItemSchema,
+      syncTimestamp
     )
   }
 
@@ -1152,7 +1251,8 @@ export class StripeSync {
 
   async upsertSubscriptionSchedules(
     subscriptionSchedules: Stripe.SubscriptionSchedule[],
-    backfillRelatedEntities?: boolean
+    backfillRelatedEntities?: boolean,
+    syncTimestamp?: string
   ): Promise<Stripe.SubscriptionSchedule[]> {
     if (backfillRelatedEntities ?? this.config.backfillRelatedEntities) {
       const customerIds = getUniqueIds(subscriptionSchedules, 'customer')
@@ -1161,10 +1261,11 @@ export class StripeSync {
     }
 
     // Run it
-    const rows = await this.postgresClient.upsertMany(
+    const rows = await this.postgresClient.upsertManyWithTimestampProtection(
       subscriptionSchedules,
       'subscription_schedules',
-      subscriptionScheduleSchema
+      subscriptionScheduleSchema,
+      syncTimestamp
     )
 
     return rows
@@ -1172,7 +1273,8 @@ export class StripeSync {
 
   async upsertSubscriptions(
     subscriptions: Stripe.Subscription[],
-    backfillRelatedEntities?: boolean
+    backfillRelatedEntities?: boolean,
+    syncTimestamp?: string
   ): Promise<Stripe.Subscription[]> {
     if (backfillRelatedEntities ?? this.config.backfillRelatedEntities) {
       const customerIds = getUniqueIds(subscriptions, 'customer')
@@ -1185,16 +1287,17 @@ export class StripeSync {
     )
 
     // Run it
-    const rows = await this.postgresClient.upsertMany(
+    const rows = await this.postgresClient.upsertManyWithTimestampProtection(
       subscriptions,
       'subscriptions',
-      subscriptionSchema
+      subscriptionSchema,
+      syncTimestamp
     )
 
     // Upsert subscription items into a separate table
     // need to run after upsert subscription cos subscriptionItems will reference the subscription
     const allSubscriptionItems = subscriptions.flatMap((subscription) => subscription.items.data)
-    await this.upsertSubscriptionItems(allSubscriptionItems)
+    await this.upsertSubscriptionItems(allSubscriptionItems, syncTimestamp)
 
     // We have to mark existing subscription item in db as deleted
     // if it doesn't exist in current subscriptionItems list


### PR DESCRIPTION
This PR introduces a timestamp protection for upserts.

### What is the current behavior?
Since the system upserts invoices without checking the recency of the state, we may end up with inconsistent data when an older webhook arrives out of order.

### What is the new behavior?
This PR introduces a general safeguard for upserting - the `upsertManyWithTimestampProtection` function. This function uses a SQL statement with a `WHERE` clause that only updates records when the incoming `last_synced_at` timestamp is newer than the existing one. This prevents older webhook events from overwriting newer data, ensuring data consistency. 

It also:
- Adds a new migration to add the last_synced_at column to all entities: charges, coupons, credit notes, customers, disputes, early fraud warnings, events, invoices, payment intents, payment methods, payouts, plans, prices, products, refunds, reviews, setup intents, subscription items, subscription schedules, subscriptions, and tax IDs.
- Adds the `syncTimestamp` parameter to the `upsert*` methods, allowing webhook handlers to pass the webhook's `created_at` timestamp, which is then used as the `last_synced_at` value for timestamp-based protection