### PR TITLE
feat: pick objects to revalidate via API

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -50,7 +50,7 @@ Set your webhook endpoint in the Stripe dashboard to point to your server’s `/
 | `AUTO_EXPAND_LISTS`                | Fetch all list items from Stripe (default: false)                   | No       |
 | `BACKFILL_RELATED_ENTITIES`        | Backfill related entities for foreign key integrity (default: true) | No       |
 | `MAX_POSTGRES_CONNECTIONS`         | Max Postgres connection pool size (default: 10)                     | No       |
-| `REVALIDATE_ENTITY_VIA_STRIPE_API` | Always fetch latest entity from Stripe (default: false)             | No       |
+| `REVALIDATE_OBJECTS_VIA_STRIPE_API` | Always fetch latest entity from Stripe (default: false)             | No       |
 
 ## Endpoints
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -36,18 +36,18 @@ await sync.processWebhook(payload, signature)
 
 ## Configuration
 
-| Option                         | Type    | Description                                                                |
-| ------------------------------ | ------- | -------------------------------------------------------------------------- |
-| `databaseUrl`                  | string  | Postgres connection string                                                 |
-| `schema`                       | string  | Database schema name (default: `stripe`)                                   |
-| `stripeSecretKey`              | string  | Stripe secret key                                                          |
-| `stripeWebhookSecret`          | string  | Stripe webhook signing secret                                              |
-| `stripeApiVersion`             | string  | Stripe API version (default: `2020-08-27`)                                 |
-| `autoExpandLists`              | boolean | Fetch all list items from Stripe (not just the default 10)                 |
-| `backfillRelatedEntities`      | boolean | Ensure related entities are present for foreign key integrity              |
-| `revalidateEntityViaStripeApi` | boolean | Always fetch latest entity from Stripe instead of trusting webhook payload |
-| `maxPostgresConnections`       | number  | Maximum Postgres connections                                               |
-| `logger`                       | Logger  | Logger instance (pino)                                                     |
+| Option                          | Type    | Description                                                                                                                                                                                                                                                                                               |
+| ------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `databaseUrl`                   | string  | Postgres connection string                                                                                                                                                                                                                                                                                |
+| `schema`                        | string  | Database schema name (default: `stripe`)                                                                                                                                                                                                                                                                  |
+| `stripeSecretKey`               | string  | Stripe secret key                                                                                                                                                                                                                                                                                         |
+| `stripeWebhookSecret`           | string  | Stripe webhook signing secret                                                                                                                                                                                                                                                                             |
+| `stripeApiVersion`              | string  | Stripe API version (default: `2020-08-27`)                                                                                                                                                                                                                                                                |
+| `autoExpandLists`               | boolean | Fetch all list items from Stripe (not just the default 10)                                                                                                                                                                                                                                                |
+| `backfillRelatedEntities`       | boolean | Ensure related entities are present for foreign key integrity                                                                                                                                                                                                                                             |
+| `revalidateObjectsViaStripeApi` | Array   | Always fetch latest entity from Stripe instead of trusting webhook payload, possible values: charge, credit_note, customer, dispute, invoice, payment_intent, payment_method, plan, price, product, refund, review, radar.early_fraud_warning, setup_intent, subscription, subscription_schedule, tax_id |
+| `maxPostgresConnections`        | number  | Maximum Postgres connections                                                                                                                                                                                                                                                                              |
+| `logger`                        | Logger  | Logger instance (pino)                                                                                                                                                                                                                                                                                    |
 
 ## Database Schema
 

--- a/packages/fastify-app/.env.sample
+++ b/packages/fastify-app/.env.sample
@@ -34,5 +34,5 @@ BACKFILL_RELATED_ENTITIES=true
 MAX_POSTGRES_CONNECTIONS=20
 
 # If true, the webhook data is not used and instead the webhook is just a trigger to fetch the entity from Stripe again. This ensures that a race condition with failed webhooks can never accidentally overwrite the data with an older state.
-# Default: false
-REVALIDATE_ENTITY_VIA_STRIPE_API=false
+# Default: 
+REVALIDATE_OBJECTS_VIA_STRIPE_API=payment_intent,invoice,customer,subscription

--- a/packages/fastify-app/README.md
+++ b/packages/fastify-app/README.md
@@ -38,19 +38,19 @@ Set your webhook endpoint in the Stripe dashboard to point to your server’s `/
 
 ## Environment Variables
 
-| Variable                           | Description                                                         | Required |
-| ---------------------------------- | ------------------------------------------------------------------- | -------- |
-| `DATABASE_URL`                     | Postgres connection string (with `search_path=stripe`)              | Yes      |
-| `STRIPE_WEBHOOK_SECRET`            | Stripe webhook signing secret                                       | Yes      |
-| `API_KEY`                          | API key for admin endpoints (backfilling, etc.)                     | Yes      |
-| `SCHEMA`                           | Database schema name (default: `stripe`)                            | No       |
-| `STRIPE_SECRET_KEY`                | Stripe secret key (needed for active sync/backfill)                 | No       |
-| `PORT`                             | Port to run the server on (default: 8080)                           | No       |
-| `STRIPE_API_VERSION`               | Stripe API version (default: `2020-08-27`)                          | No       |
-| `AUTO_EXPAND_LISTS`                | Fetch all list items from Stripe (default: false)                   | No       |
-| `BACKFILL_RELATED_ENTITIES`        | Backfill related entities for foreign key integrity (default: true) | No       |
-| `MAX_POSTGRES_CONNECTIONS`         | Max Postgres connection pool size (default: 10)                     | No       |
-| `REVALIDATE_ENTITY_VIA_STRIPE_API` | Always fetch latest entity from Stripe (default: false)             | No       |
+| Variable                           | Description                                                                                                                                                                                                                                                                                              | Required |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `DATABASE_URL`                     | Postgres connection string (with `search_path=stripe`)                                                                                                                                                                                                                                                   | Yes      |
+| `STRIPE_WEBHOOK_SECRET`            | Stripe webhook signing secret                                                                                                                                                                                                                                                                            | Yes      |
+| `API_KEY`                          | API key for admin endpoints (backfilling, etc.)                                                                                                                                                                                                                                                          | Yes      |
+| `SCHEMA`                           | Database schema name (default: `stripe`)                                                                                                                                                                                                                                                                 | No       |
+| `STRIPE_SECRET_KEY`                | Stripe secret key (needed for active sync/backfill)                                                                                                                                                                                                                                                      | No       |
+| `PORT`                             | Port to run the server on (default: 8080)                                                                                                                                                                                                                                                                | No       |
+| `STRIPE_API_VERSION`               | Stripe API version (default: `2020-08-27`)                                                                                                                                                                                                                                                               | No       |
+| `AUTO_EXPAND_LISTS`                | Fetch all list items from Stripe (default: false)                                                                                                                                                                                                                                                        | No       |
+| `BACKFILL_RELATED_ENTITIES`        | Backfill related entities for foreign key integrity (default: true)                                                                                                                                                                                                                                      | No       |
+| `MAX_POSTGRES_CONNECTIONS`         | Max Postgres connection pool size (default: 10)                                                                                                                                                                                                                                                          | No       |
+| `REVALIDATE_OBJECTS_VIA_STRIPE_API` | Always fetch latest entity from Stripe instead of trusting webhook payload, possible values: charge, credit_note, customer, dispute, invoice, payment_intent, payment_method, plan, price, product, refund, review, radar.early_fraud_warning, setup_intent, subscription, subscription_schedule, tax_id | No       |
 
 ## Endpoints
 

--- a/packages/fastify-app/src/test/revalidate.test.ts
+++ b/packages/fastify-app/src/test/revalidate.test.ts
@@ -1,0 +1,48 @@
+import type Stripe from 'stripe'
+import { StripeSync } from '@supabase/stripe-sync-engine'
+import { vitest, beforeAll, describe, test, expect } from 'vitest'
+import { runMigrations } from '@supabase/stripe-sync-engine'
+import { getConfig } from '../utils/config'
+import { mockStripe } from './helpers/mockStripe'
+import { logger } from '../logger'
+
+let stripeSync: StripeSync
+
+beforeAll(async () => {
+  process.env.REVALIDATE_OBJECTS_VIA_STRIPE_API = 'invoice'
+
+  const config = getConfig()
+  await runMigrations({
+    databaseUrl: config.databaseUrl,
+    schema: config.schema,
+    logger,
+  })
+
+  stripeSync = new StripeSync(config)
+  const stripe = Object.assign(stripeSync.stripe, mockStripe)
+  vitest.spyOn(stripeSync, 'stripe', 'get').mockReturnValue(stripe)
+})
+
+describe('invoices', () => {
+  test('should revalidate entity if enabled', async () => {
+    const invoices = [
+      {
+        id: 'in_xyz',
+        object: 'invoice',
+        auto_advance: true,
+        lines: {
+          data: [{ id: 'li_123' }],
+          has_more: false,
+        },
+      } as Stripe.Invoice,
+    ]
+
+    await stripeSync.upsertInvoices(invoices, false)
+
+    const lineItems = await stripeSync.postgresClient.query(
+      `select lines->'data' as lines from stripe.invoices where id = 'in_xyz' limit 1`
+    )
+    expect(lineItems.rows[0].lines).toEqual([{ id: 'li_123' }])
+    expect(mockStripe.invoices.retrieve).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/fastify-app/src/utils/config.ts
+++ b/packages/fastify-app/src/utils/config.ts
@@ -1,5 +1,5 @@
+import type { RevalidateEntity } from '@supabase/stripe-sync-engine'
 import { config } from 'dotenv'
-import { type RevalidateEntity } from '@stripe-sync-engine/sync-engine'
 
 function getConfigFromEnv(key: string, defaultValue?: string): string {
   const value = process.env[key]

--- a/packages/fastify-app/src/utils/config.ts
+++ b/packages/fastify-app/src/utils/config.ts
@@ -1,4 +1,5 @@
 import { config } from 'dotenv'
+import { type RevalidateEntity } from '@stripe-sync-engine/sync-engine'
 
 function getConfigFromEnv(key: string, defaultValue?: string): string {
   const value = process.env[key]
@@ -41,7 +42,7 @@ export type StripeSyncServerConfig = {
 
   maxPostgresConnections?: number
 
-  revalidateEntityViaStripeApi: boolean
+  revalidateObjectsViaStripeApi: Array<RevalidateEntity>
 
   port: number
 }
@@ -60,7 +61,9 @@ export function getConfig(): StripeSyncServerConfig {
     autoExpandLists: getConfigFromEnv('AUTO_EXPAND_LISTS', 'false') === 'true',
     backfillRelatedEntities: getConfigFromEnv('BACKFILL_RELATED_ENTITIES', 'true') === 'true',
     maxPostgresConnections: Number(getConfigFromEnv('MAX_POSTGRES_CONNECTIONS', '10')),
-    revalidateEntityViaStripeApi:
-      getConfigFromEnv('REVALIDATE_ENTITY_VIA_STRIPE_API', 'false') === 'true',
+    revalidateObjectsViaStripeApi: getConfigFromEnv('REVALIDATE_OBJECTS_VIA_STRIPE_API', '')
+      .split(',')
+      .map((it) => it.trim())
+      .filter((it) => it.length > 0) as Array<RevalidateEntity>,
   }
 }

--- a/packages/sync-engine/README.md
+++ b/packages/sync-engine/README.md
@@ -39,18 +39,18 @@ await sync.processWebhook(payload, signature)
 
 ## Configuration
 
-| Option                         | Type    | Description                                                                |
-| ------------------------------ | ------- | -------------------------------------------------------------------------- |
-| `databaseUrl`                  | string  | Postgres connection string                                                 |
-| `schema`                       | string  | Database schema name (default: `stripe`)                                   |
-| `stripeSecretKey`              | string  | Stripe secret key                                                          |
-| `stripeWebhookSecret`          | string  | Stripe webhook signing secret                                              |
-| `stripeApiVersion`             | string  | Stripe API version (default: `2020-08-27`)                                 |
-| `autoExpandLists`              | boolean | Fetch all list items from Stripe (not just the default 10)                 |
-| `backfillRelatedEntities`      | boolean | Ensure related entities are present for foreign key integrity              |
-| `revalidateEntityViaStripeApi` | boolean | Always fetch latest entity from Stripe instead of trusting webhook payload |
-| `maxPostgresConnections`       | number  | Maximum Postgres connections                                               |
-| `logger`                       | Logger  | Logger instance (pino)                                                     |
+| Option                          | Type    | Description                                                                                                                                                                                                                                                                                              |
+| ------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `databaseUrl`                   | string  | Postgres connection string                                                                                                                                                                                                                                                                               |
+| `schema`                        | string  | Database schema name (default: `stripe`)                                                                                                                                                                                                                                                                 |
+| `stripeSecretKey`               | string  | Stripe secret key                                                                                                                                                                                                                                                                                        |
+| `stripeWebhookSecret`           | string  | Stripe webhook signing secret                                                                                                                                                                                                                                                                            |
+| `stripeApiVersion`              | string  | Stripe API version (default: `2020-08-27`)                                                                                                                                                                                                                                                               |
+| `autoExpandLists`               | boolean | Fetch all list items from Stripe (not just the default 10)                                                                                                                                                                                                                                               |
+| `backfillRelatedEntities`       | boolean | Ensure related entities are present for foreign key integrity                                                                                                                                                                                                                                            |
+| `revalidateObjectsViaStripeApi` | Array   | Always fetch latest entity from Stripe instead of trusting webhook payload, possible values: charge, credit_note, customer, dispute, invoice, payment_intent, payment_method, plan, price, product, refund, review, radar.early_fraud_warning, setup_intent, subscription, subscription_schedule, tax_id |
+| `maxPostgresConnections`        | number  | Maximum Postgres connections                                                                                                                                                                                                                                                                             |
+| `logger`                        | Logger  | Logger instance (pino)                                                                                                                                                                                                                                                                                   |
 
 ## Database Schema
 

--- a/packages/sync-engine/src/stripeSync.ts
+++ b/packages/sync-engine/src/stripeSync.ts
@@ -16,7 +16,13 @@ import { taxIdSchema } from './schemas/tax_id'
 import { subscriptionItemSchema } from './schemas/subscription_item'
 import { subscriptionScheduleSchema } from './schemas/subscription_schedules'
 import { subscriptionSchema } from './schemas/subscription'
-import { StripeSyncConfig, Sync, SyncBackfill, SyncBackfillParams } from './types'
+import {
+  StripeSyncConfig,
+  Sync,
+  SyncBackfill,
+  SyncBackfillParams,
+  type RevalidateEntity,
+} from './types'
 import { earlyFraudWarningSchema } from './schemas/early_fraud_warning'
 import { reviewSchema } from './schemas/review'
 import { refundSchema } from './schemas/refund'
@@ -436,13 +442,13 @@ export class StripeSync {
     }
   }
 
-  private async fetchOrUseWebhookData<T extends { id?: string }>(
+  private async fetchOrUseWebhookData<T extends { id?: string; object: string }>(
     entity: T,
     fetchFn: (id: string) => Promise<T>
   ): Promise<T> {
     if (!entity.id) return entity
 
-    if (this.config.revalidateEntityViaStripeApi) {
+    if (this.config.revalidateObjectsViaStripeApi?.includes(entity.object as RevalidateEntity)) {
       return fetchFn(entity.id)
     }
 

--- a/packages/sync-engine/src/types.ts
+++ b/packages/sync-engine/src/types.ts
@@ -1,5 +1,24 @@
 import pino from 'pino'
 
+export type RevalidateEntity =
+  | 'charge'
+  | 'credit_note'
+  | 'customer'
+  | 'dispute'
+  | 'invoice'
+  | 'payment_intent'
+  | 'payment_method'
+  | 'plan'
+  | 'price'
+  | 'product'
+  | 'refund'
+  | 'review'
+  | 'radar.early_fraud_warning'
+  | 'setup_intent'
+  | 'subscription'
+  | 'subscription_schedule'
+  | 'tax_id'
+
 export type StripeSyncConfig = {
   /** Postgres database URL including authentication */
   databaseUrl: string
@@ -33,7 +52,7 @@ export type StripeSyncConfig = {
    *
    * Default: false
    */
-  revalidateEntityViaStripeApi?: boolean
+  revalidateObjectsViaStripeApi?: Array<RevalidateEntity>
 
   maxPostgresConnections?: number
 


### PR DESCRIPTION
Instead of an all or nothing revalidation, it is now possible to define the entities that shall be refetched via Stripe API before syncing. This adds some flexibility on what entities should be refetched or not.