### PR TITLE
feat: add 'paused' value to stripe.subscription_status enum

### DIFF
--- a/packages/sync-engine/src/database/migrations/0039_add_paused_to_subscription_status.sql
+++ b/packages/sync-engine/src/database/migrations/0039_add_paused_to_subscription_status.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "stripe"."subscription_status" ADD VALUE 'paused';


### PR DESCRIPTION
## What kind of change does this PR introduce?

  Feature: Add support for "paused" subscription status in the database enum.

 ## What is the current behavior?

  The subscription_status enum in the database currently supports: trialing, active, canceled, incomplete,
  incomplete_expired, past_due, and unpaid. However, Stripe supports an additional "paused" status for
  subscriptions, but this value cannot be stored in the database due to the enum constraint.
  Related issue: https://github.com/supabase/stripe-sync-engine/issues/196

 ## What is the new behavior?

  • The subscription_status enum now includes the "paused" value
  • Subscriptions with "paused" status from Stripe webhooks can now be properly stored in the database
  • The existing webhook handler for customer.subscription.paused events will now work correctly with
    database persistence


 ## Additional context

  This change aligns the database schema with Stripe's complete subscription status API. The code already
  handles customer.subscription.paused webhook events in stripeSync.ts, but the database enum was missing
  this value, potentially causing issues when trying to sync paused subscriptions.
  Migration details:
  • Added migration file: 0039_add_paused_to_subscription_status.sql
  • Uses PostgreSQL ALTER TYPE ... ADD VALUE to extend the existing enum
  • Safe operation that doesn't affect existing data