### PR TITLE
chore: add application name to postgres connection

### DIFF
--- a/packages/sync-engine/src/stripeSync.ts
+++ b/packages/sync-engine/src/stripeSync.ts
@@ -67,6 +67,8 @@ export class StripeSync {
 
     const poolConfig = config.poolConfig ?? ({} as PoolConfig)
 
+    poolConfig.application_name = 'stripe-sync-engine'
+
     if (config.databaseUrl) {
       poolConfig.connectionString = config.databaseUrl
     }


### PR DESCRIPTION
Can add version in future but currently not easy to find out current version as it is not persisted anywhere (i.e. not available in package.json)