### PR TITLE
fix(sync-engine): add missing break in payment_intent switch case

### DIFF
--- a/packages/sync-engine/src/stripeSync.ts
+++ b/packages/sync-engine/src/stripeSync.ts
@@ -708,6 +708,7 @@ export class StripeSync {
         break
       case 'payment_intent':
         paymentIntents = await this.syncPaymentIntents(params)
+        break
       case 'plan':
         plans = await this.syncPlans(params)
         break


### PR DESCRIPTION
## Summary

Fixes #222

The `payment_intent` case in `syncBackfill()` was missing a `break` statement, causing unintended fallthrough to the `plan` case.

**Before:** Calling `syncBackfill({ object: 'payment_intent' })` would sync both payment intents AND plans.

**After:** Only payment intents are synced as expected.

## Test plan

- [x] Verified the switch case structure matches other cases in the same function