### PR TITLE
refactor: stream batched items to db during backfill

### DIFF
--- a/packages/sync-engine/src/stripeSync.ts
+++ b/packages/sync-engine/src/stripeSync.ts
@@ -1017,6 +1017,7 @@ export class StripeSync {
     for await (const item of fetch()) {
       chunk.push(item)
       synced++
+      if (synced % 1000 === 0) this.config.logger?.info(`Synced ${synced} items`)
 
       if (chunk.length >= chunkSize) {
         await upsert(chunk)


### PR DESCRIPTION
Closes #228

Streams and upserts in chunks as items arrive, instead of collecting all first.

- Chunks of 250 items
- Upsert runs while fetch continues
- Logging: removes mid-sync count log (total unknown until done)