### PR TITLE
feat(sync-engine): add close() method to release database connections

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -139,3 +139,11 @@ await sync.syncBackfill({
 
 > **Note:**
 > For large Stripe accounts (more than 10,000 objects), it is recommended to write a script that loops through each day and sets the `created` date filters to the start and end of day. This avoids timeouts and memory issues when syncing large datasets.
+
+## Cleanup
+
+Call `close()` to release database connections when shutting down:
+
+```ts
+await sync.close()
+```

--- a/packages/sync-engine/src/database/postgres.ts
+++ b/packages/sync-engine/src/database/postgres.ts
@@ -229,4 +229,8 @@ export class PostgresClient {
     })
     return cleansed
   }
+
+  async close(): Promise<void> {
+    await this.pool.end()
+  }
 }

--- a/packages/sync-engine/src/stripeSync.ts
+++ b/packages/sync-engine/src/stripeSync.ts
@@ -1710,6 +1710,10 @@ export class StripeSync {
 
     return entities
   }
+
+  async close(): Promise<void> {
+    await this.postgresClient.close()
+  }
 }
 
 function chunkArray<T>(array: T[], chunkSize: number): T[][] {


### PR DESCRIPTION
## Summary
`StripeSync` creates a `pg.Pool` internally but provides no way to close it. This adds a `close()` method.

## Changes
- `PostgresClient.close()` - calls `pool.end()`
- `StripeSync.close()` - delegates to `postgresClient.close()`
- Docs: added brief usage example

## Usage
```ts
await sync.close()
```