### PR TITLE
fix(sync-engine): apply schema default early (#227)

### DIFF
--- a/packages/sync-engine/src/stripeSync.ts
+++ b/packages/sync-engine/src/stripeSync.ts
@@ -51,6 +51,8 @@ export class StripeSync {
   postgresClient: PostgresClient
 
   constructor(private config: StripeSyncConfig) {
+    this.config.schema = config.schema || DEFAULT_SCHEMA
+
     this.stripe = new Stripe(config.stripeSecretKey, {
       // https://github.com/stripe/stripe-node#configuration
       // @ts-ignore
@@ -86,7 +88,7 @@ export class StripeSync {
     }
 
     this.postgresClient = new PostgresClient({
-      schema: config.schema || DEFAULT_SCHEMA,
+      schema: this.config.schema,
       poolConfig,
     })
   }


### PR DESCRIPTION
Fixes #227

`this.config.schema` was accessed directly in SQL queries but the default was only applied when creating `PostgresClient`. This applies the default at constructor start.