### PR TITLE
feat(sync-engine): add onProgress callback to track sync progress

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -131,11 +131,15 @@ To backfill Stripe data (e.g., all products created after a certain date), use t
 await sync.syncBackfill({
   object: 'product',
   created: { gte: 1643872333 }, // Unix timestamp
+  onProgress: (progress) => {
+    console.log(`Synced ${progress.synced} products`)
+  },
 })
 ```
 
 - `object` can be one of: `all`, `charge`, `customer`, `dispute`, `invoice`, `payment_method`, `payment_intent`, `plan`, `price`, `product`, `setup_intent`, `subscription`.
 - `created` is a Stripe RangeQueryParam and supports `gt`, `gte`, `lt`, `lte`.
+- `onProgress` (optional) is a callback that fires after each batch of 250 items with cumulative progress: `{ synced: number, object?: string }`.
 
 > **Note:**
 > For large Stripe accounts (more than 10,000 objects), it is recommended to write a script that loops through each day and sets the `created` date filters to the start and end of day. This avoids timeouts and memory issues when syncing large datasets.

--- a/packages/sync-engine/README.md
+++ b/packages/sync-engine/README.md
@@ -90,11 +90,15 @@ To backfill Stripe data (e.g., all products created after a certain date), use t
 await sync.syncBackfill({
   object: 'product',
   created: { gte: 1643872333 }, // Unix timestamp
+  onProgress: (progress) => {
+    console.log(`Synced ${progress.synced} products`)
+  },
 })
 ```
 
 - `object` can be one of: `all`, `charge`, `customer`, `dispute`, `invoice`, `payment_method`, `payment_intent`, `plan`, `price`, `product`, `setup_intent`, `subscription`.
 - `created` is a Stripe RangeQueryParam and supports `gt`, `gte`, `lt`, `lte`.
+- `onProgress` (optional) is a callback that fires after each batch of 250 items with cumulative progress: `{ synced: number, object?: string }`.
 
 > **Note:**
 > For large Stripe accounts (more than 10,000 objects), it is recommended to write a script that loops through each day and sets the `created` date filters to the start and end of day. This avoids timeouts and memory issues when syncing large datasets.

--- a/packages/sync-engine/src/types.ts
+++ b/packages/sync-engine/src/types.ts
@@ -87,6 +87,7 @@ export type SyncObject =
   | 'checkout_sessions'
 export interface Sync {
   synced: number
+  object?: SyncObject
 }
 
 export interface SyncBackfill {
@@ -133,14 +134,18 @@ export interface SyncBackfillParams {
   }
   object?: SyncObject
   backfillRelatedEntities?: boolean
+  onProgress?: (progress: Sync) => void
 }
 
 export interface SyncEntitlementsParams {
   object: 'entitlements'
   customerId: string
   pagination?: Pick<Stripe.PaginationParams, 'starting_after' | 'ending_before'>
+  onProgress?: (progress: Sync) => void
 }
+
 export interface SyncFeaturesParams {
   object: 'features'
   pagination?: Pick<Stripe.PaginationParams, 'starting_after' | 'ending_before'>
+  onProgress?: (progress: Sync) => void
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds an `onProgress` callback to track sync progress in real-time.

## What is the current behavior?

There's no way to track progress during sync operations - you have to wait for the entire sync to complete without knowing how many items have been processed.

## What is the new behavior?

All sync methods now accept an optional `onProgress` callback that fires after each batch of 250 items:

- Added `object?: SyncObject` to the `Sync` interface
- Added `onProgress?: (progress: Sync) => void` to sync params interfaces
- When using `syncBackfill({ object: 'all' })`, the callback includes the object type so you can tell which entity is being synced

**Usage:**

```typescript
// Track a specific entity
await sync.syncProducts({
  onProgress: ({ synced }) => console.log(`Synced ${synced} products`)
})

// Track all entities
await sync.syncBackfill({
  object: 'all',
  onProgress: ({ synced, object }) => console.log(`Synced ${synced} ${object}`)
})
```