### PR TITLE
docs: add missing checkout.session.expired to webhook support list

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ To deploy the sync-engine to a Supabase Edge Function, follow this [guide](./doc
 - [x] `checkout.session.async_payment_failed` 🟢
 - [x] `checkout.session.async_payment_succeeded` 🟢
 - [x] `checkout.session.completed` 🟢
+- [x] `checkout.session.expired` 🟢
 - [x] `credit_note.created` 🟢
 - [x] `credit_note.updated` 🟢
 - [x] `credit_note.voided` 🟢

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,7 @@ This project synchronizes your Stripe account to a PostgreSQL database. It can b
 - [x] `checkout.session.async_payment_failed` 🟢
 - [x] `checkout.session.async_payment_succeeded` 🟢
 - [x] `checkout.session.completed` 🟢
+- [x] `checkout.session.expired` 🟢
 - [x] `credit_note.created` 🟢
 - [x] `credit_note.updated` 🟢
 - [x] `credit_note.voided` 🟢


### PR DESCRIPTION
This event was already implemented in the code (see `stripeSync.ts:143`) but missing from the documentation.

Found while investigating #97.