### PR TITLE
feat(sync-engine): implement AsyncDisposable interface for await using

### DIFF
--- a/packages/sync-engine/src/stripeSync.ts
+++ b/packages/sync-engine/src/stripeSync.ts
@@ -1718,6 +1718,10 @@ export class StripeSync {
   async close(): Promise<void> {
     await this.postgresClient.close()
   }
+
+  async [Symbol.asyncDispose](): Promise<void> {
+    await this.close()
+  }
 }
 
 function chunkArray<T>(array: T[], chunkSize: number): T[][] {


### PR DESCRIPTION
Per @kevcodez suggestion in #230.

Adds `Symbol.asyncDispose` so users can do:

```ts
await using sync = new StripeSync({ ... })
// auto-closes when out of scope
```

`close()` still works for Node < 20.