### PR TITLE
feat: add support to flexible billing mode

### DIFF
--- a/packages/sync-engine/src/database/migrations/0041_add_billing_mode.sql
+++ b/packages/sync-engine/src/database/migrations/0041_add_billing_mode.sql
@@ -1,0 +1,9 @@
+-- Add billing_mode column to subscriptions and subscription_schedules tables
+-- This field stores the billing mode configuration for flexible billing support
+-- See: https://docs.stripe.com/billing/subscriptions/billing-mode
+
+ALTER TABLE "stripe"."subscriptions" 
+ADD COLUMN IF NOT EXISTS "billing_mode" jsonb;
+
+ALTER TABLE "stripe"."subscription_schedules" 
+ADD COLUMN IF NOT EXISTS "billing_mode" jsonb;

--- a/packages/sync-engine/src/schemas/subscription.ts
+++ b/packages/sync-engine/src/schemas/subscription.ts
@@ -37,5 +37,6 @@ export const subscriptionSchema: EntitySchema = {
     'customer',
     'latest_invoice',
     'plan',
+    'billing_mode',
   ],
 } as const

--- a/packages/sync-engine/src/schemas/subscription_schedules.ts
+++ b/packages/sync-engine/src/schemas/subscription_schedules.ts
@@ -20,5 +20,6 @@ export const subscriptionScheduleSchema: EntitySchema = {
     'status',
     'subscription',
     'test_clock',
+    'billing_mode',
   ],
 } as const


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature - Add support for Flexible Billing Mode to `subscription` & `subscription_schedules`

## What is the current behavior?

The sync engine does not capture the `billing_mode` field from Stripe's subscription and subscription_schedule objects. This field is required to support Stripe's new [Flexible Billing Mode](https://docs.stripe.com/billing/subscriptions/billing-mode) introduced in API version `2025-06-30.basil`.

## What is the new behavior?

Added `billing_mode` (JSONB) column to:
- `stripe.subscriptions` table
- `stripe.subscription_schedules` table

**Files changed:**
- `packages/sync-engine/src/schemas/subscription.ts` - Added `billing_mode` to properties
- `packages/sync-engine/src/schemas/subscription_schedules.ts` - Added `billing_mode` to properties  
- `packages/sync-engine/src/database/migrations/0041_add_billing_mode.sql` - Migration to add columns

**Example `billing_mode` value:**
{
  "type": "flexible",
  "flexible": {
    "proration_discounts": "included"
  }
}
