### PR TITLE
Remove alter function set_updated_at() owner to postgres;

### DIFF
--- a/packages/sync-engine/src/database/migrations/0012_add_updated_at.sql
+++ b/packages/sync-engine/src/database/migrations/0012_add_updated_at.sql
@@ -8,8 +8,6 @@ begin
 end;
 $$;
 
-alter function set_updated_at() owner to postgres;
-
 alter table stripe.subscriptions
     add updated_at timestamptz default timezone('utc'::text, now()) not null;
 


### PR DESCRIPTION
This removes the explicit ownership change on `set_updated_at()`.

This line assumes the existence of user `postgres` (which does not in my case). It will be owned by the user that creates it and that is fine.

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If not user postgres but another database user, you run into problems when the database user is explicitly named:

```cmd
{"type":"Error","message":"Migration failed. Reason: An error occurred
 running 'add_updated_at'. Rolled back this migration. No further migrations were run. Reason: must be able to SET ROLE \"postgres\"","stack":"Error: Migration failed. Reason: An error
 occurred running 'add_updated_at'. Rolled back this migration. No further migrations were run. Reason: must be able to SET ROLE \"postgres\"\n    at /app/node_modules/.pnpm/pg-node-mi
grations@0.0.8/node_modules/pg-node-migrations/dist/migrate.js:108:27\n    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)\n    at async /app/node_module
s/.pnpm/pg-node-migrations@0.0.8/node_modules/pg-node-migrations/dist/with-lock.js:25:28\n    at async connectAndMigrate (/app/packages/sync-engine/dist/index.cjs:2191:5)\n    at async
 runMigrations (/app/packages/sync-engine/dist/index.cjs:2210:5)","cause":"An error occurred running 'add_updated_at'. Rolled back this migration. No further migrations were run. Reaso
n: must be able to SET ROLE \"postgres\""},"msg":"Error running migrations"}
```

## What is the new behavior?

The function is now owned by the database user that creates it.
