### PR TITLE
fix(sync-engine): Removes unique constraint from features & active entitlements

### DIFF
--- a/packages/sync-engine/src/database/migrations/0042_remove_lookup_key_unique.sql
+++ b/packages/sync-engine/src/database/migrations/0042_remove_lookup_key_unique.sql
@@ -1,0 +1,7 @@
+
+ALTER TABLE stripe.active_entitlements 
+DROP CONSTRAINT IF EXISTS active_entitlements_lookup_key_key;
+
+
+ALTER TABLE stripe.features 
+DROP CONSTRAINT IF EXISTS features_lookup_key_key;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?
Currently the lookup_key is set to be unique
https://github.com/supabase/stripe-sync-engine/issues/260

## What is the new behavior?
The lookup_key can appear across different records

