### PR TITLE
fix: drop unique constraint on features.lookup_key

### DIFF
--- a/packages/sync-engine/src/database/migrations/0042_drop_features_lookup_key_unique.sql
+++ b/packages/sync-engine/src/database/migrations/0042_drop_features_lookup_key_unique.sql
@@ -1,0 +1,2 @@
+ALTER TABLE features
+DROP CONSTRAINT IF EXISTS features_lookup_key_key;


### PR DESCRIPTION
#260 

### What changed
Drops the UNIQUE constraint on `features.lookup_key`.

### Why
Stripe allows reuse of `lookup_key` once a feature is archived/inactive.
The current schema assumes uniqueness and causes sync failures.

### How
Adds a migration that safely removes the unique constraint using
`DROP CONSTRAINT IF EXISTS`.
