### PR TITLE
Fix hardcoded postgres role on set_updated_at function

### DIFF
--- a/packages/sync-engine/src/database/migrations/0043_fix_set_updated_at_owner.sql
+++ b/packages/sync-engine/src/database/migrations/0043_fix_set_updated_at_owner.sql
@@ -1,0 +1,5 @@
+-- Migration 0012 hardcoded "postgres" as the function owner, which fails on
+-- PostgreSQL installations where that role does not exist (e.g. managed cloud
+-- databases). Re-assign ownership to the role executing the migration so it
+-- works in any environment.
+ALTER FUNCTION set_updated_at() OWNER TO CURRENT_USER;


### PR DESCRIPTION
## Problem

Migration `0012_add_updated_at.sql` includes:

```sql
alter function set_updated_at() owner to postgres;
```

This hard-codes the `postgres` superuser role. On managed PostgreSQL services (RDS, Cloud SQL, Azure Database, Supabase projects with custom roles) and any installation where the `postgres` role does not exist, this statement fails with:

```
ERROR:  role "postgres" does not exist
```

The entire migration aborts, leaving `updated_at` columns and triggers uninstalled.

## Approach

Modifying `0012` directly would change its checksum and break `pg-node-migrations` for all existing installations that have already applied it. A new migration is the safe path.

Migration `0043_fix_set_updated_at_owner.sql` re-assigns the function to `CURRENT_USER`, which resolves to whatever role is running the migration — correct in every environment:

```sql
ALTER FUNCTION set_updated_at() OWNER TO CURRENT_USER;
```

- **New installs**: `0012` creates the function (wrong owner on non-postgres systems), `0043` immediately corrects it.
- **Existing installs that ran `0012` successfully**: `0043` updates the owner to the migrating role, which is the right behaviour.
- **Existing installs where `0012` failed**: `0043` alone cannot fix the broken state, but the schema fix should be handled separately for those users.

Fixes #77