### PR TITLE
Fix entitlement pagination truncation and invoice.upcoming crash

### DIFF
--- a/packages/sync-engine/src/stripeSync.ts
+++ b/packages/sync-engine/src/stripeSync.ts
@@ -233,7 +233,13 @@ export class StripeSync {
       case 'invoice.payment_action_required':
       case 'invoice.payment_failed':
       case 'invoice.payment_succeeded':
-      case 'invoice.upcoming':
+      case 'invoice.upcoming': {
+        // invoice.upcoming is a preview invoice with no id — it cannot be persisted.
+        this.config.logger?.info(
+          `Received webhook ${event.id}: ${event.type} — skipping (preview invoice has no id)`
+        )
+        break
+      }
       case 'invoice.sent':
       case 'invoice.voided':
       case 'invoice.marked_uncollectible':
@@ -529,12 +535,28 @@ export class StripeSync {
           .object as Stripe.Entitlements.ActiveEntitlementSummary
         let entitlements = activeEntitlementSummary.entitlements
         let refetched = false
-        if (this.config.revalidateObjectsViaStripeApi?.includes('entitlements')) {
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const { lastResponse, ...rest } = await this.stripe.entitlements.activeEntitlements.list({
+        if (
+          this.config.revalidateObjectsViaStripeApi?.includes('entitlements') ||
+          entitlements.has_more
+        ) {
+          // Fetch all pages from the API — the webhook payload is capped at 10 items
+          // and has_more signals that there are more entitlements than were included.
+          const allData: Stripe.Entitlements.ActiveEntitlement[] = []
+          let page = await this.stripe.entitlements.activeEntitlements.list({
             customer: activeEntitlementSummary.customer,
-          })
-          entitlements = rest
+            limit: 100,
+          } as Stripe.Entitlements.ActiveEntitlementListParams)
+          allData.push(...page.data)
+          while (page.has_more) {
+            const lastId = page.data[page.data.length - 1].id
+            page = await this.stripe.entitlements.activeEntitlements.list({
+              customer: activeEntitlementSummary.customer,
+              limit: 100,
+              starting_after: lastId,
+            } as Stripe.Entitlements.ActiveEntitlementListParams)
+            allData.push(...page.data)
+          }
+          entitlements = { ...entitlements, data: allData, has_more: false }
           refetched = true
         }
 


### PR DESCRIPTION
## Issue #280 — Active entitlements truncated at 10 items

### Problem

Stripe webhook payloads cap nested lists at 10 items. When a customer has more than 10 active entitlements the `entitlements.active_entitlement_summary.updated` event arrives with `entitlements.has_more: true`, but the handler only reads from the API when `revalidateObjectsViaStripeApi` contains `'entitlements'`. Without that config flag the handler silently uses the truncated webhook list, deleting the entitlements that weren't included.

### Fix

Check `entitlements.has_more` in addition to the revalidation flag. When either is true, paginate the full list from the Stripe API before upserting:

```typescript
if (
  this.config.revalidateObjectsViaStripeApi?.includes('entitlements') ||
  entitlements.has_more
) {
  // paginate all pages via stripe.entitlements.activeEntitlements.list(...)
}
```

---

## Issue #121 — `invoice.upcoming` crashes with NOT NULL violation

### Problem

`invoice.upcoming` events represent preview invoices that have no `id` field. The `case 'invoice.upcoming':` fell through to the `invoice.updated` handler which called `upsertInvoices`, hitting a `NOT NULL` constraint on the `id` column and throwing an unhandled error.

### Fix

Break `invoice.upcoming` into its own case that logs the event and returns early — preview invoices are not persistable:

```typescript
case 'invoice.upcoming': {
  this.config.logger?.info(`... skipping (preview invoice has no id)`)
  break
}
```

Fixes #280
Fixes #121