### PR TITLE
fix: add tsup --shims for ESM/CJS dirname compatibility

### DIFF
--- a/packages/sync-engine/package.json
+++ b/packages/sync-engine/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "prebuild": "npm run clean",
-    "build": "tsup src/index.ts --format esm,cjs --dts && cp -r src/database/migrations dist/migrations",
+    "build": "tsup src/index.ts --format esm,cjs --dts --shims && cp -r src/database/migrations dist/migrations",
     "lint": "eslint src --ext .ts"
   },
   "files": [


### PR DESCRIPTION
Bare __dirname is a CJS-only global and is undefined in ESM contexts.
This enables tsup --shims so the ESM build has __dirname.

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Calling `runMigrations()` in ESM returns "__dirname is not defined"

## What is the new behavior?

tsup generates [shims](https://tsup.egoist.dev/#inject-cjs-and-esm-shims) so runMigrations() works both in CJS and EMS because __driname gets defined

## Additional context

> [!NOTE]
>  I let Claude Code fix this and did not write code myself. I validated the changes in my ESM Project.

I hope this is ok for you.
