### PR TITLE
feat: PGlite support + browser-sync example app

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,3 @@
 # shellcheck shell=bash
+export GH_HOST=github.com
 source_env_if_exists .envrc.local

--- a/apps/engine/package.json
+++ b/apps/engine/package.json
@@ -14,6 +14,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./lib": {
+      "bun": "./src/lib/index.ts",
+      "types": "./dist/lib/index.d.ts",
+      "import": "./dist/lib/index.js"
+    },
     "./cli": {
       "bun": "./src/cli/command.ts",
       "types": "./dist/cli/command.d.ts",

--- a/apps/engine/src/__generated__/openapi.d.ts
+++ b/apps/engine/src/__generated__/openapi.d.ts
@@ -532,6 +532,10 @@ export interface components {
                 /** @description External ID for STS AssumeRole */
                 external_id?: string;
             };
+            pglite?: true | {
+                /** @description Directory for persistent storage (omit for in-memory) */
+                data_dir?: string;
+            };
             /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
             ssl_ca_pem?: string;
         };

--- a/apps/engine/src/__generated__/openapi.d.ts
+++ b/apps/engine/src/__generated__/openapi.d.ts
@@ -532,6 +532,8 @@ export interface components {
                 /** @description External ID for STS AssumeRole */
                 external_id?: string;
             };
+            /** @description Enable experimental PGlite support (required to use pglite config or file:///memory:// URLs) */
+            allow_experimental_pglite?: boolean;
             pglite?: true | {
                 /** @description Directory for persistent storage (omit for in-memory) */
                 data_dir?: string;

--- a/apps/engine/src/__generated__/openapi.json
+++ b/apps/engine/src/__generated__/openapi.json
@@ -1572,6 +1572,10 @@
             "additionalProperties": false,
             "description": "AWS RDS IAM authentication config"
           },
+          "allow_experimental_pglite": {
+            "type": "boolean",
+            "description": "Enable experimental PGlite support (required to use pglite config or file:///memory:// URLs)"
+          },
           "pglite": {
             "anyOf": [
               {

--- a/apps/engine/src/__generated__/openapi.json
+++ b/apps/engine/src/__generated__/openapi.json
@@ -1572,6 +1572,24 @@
             "additionalProperties": false,
             "description": "AWS RDS IAM authentication config"
           },
+          "pglite": {
+            "anyOf": [
+              {
+                "type": "boolean",
+                "const": true
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "data_dir": {
+                    "type": "string",
+                    "description": "Directory for persistent storage (omit for in-memory)"
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          },
           "ssl_ca_pem": {
             "type": "string",
             "description": "PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA)"

--- a/apps/service/src/__generated__/openapi.d.ts
+++ b/apps/service/src/__generated__/openapi.d.ts
@@ -467,6 +467,10 @@ export interface components {
                 /** @description External ID for STS AssumeRole */
                 external_id?: string;
             };
+            pglite?: true | {
+                /** @description Directory for persistent storage (omit for in-memory) */
+                data_dir?: string;
+            };
             /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
             ssl_ca_pem?: string;
         };

--- a/apps/service/src/__generated__/openapi.d.ts
+++ b/apps/service/src/__generated__/openapi.d.ts
@@ -467,6 +467,8 @@ export interface components {
                 /** @description External ID for STS AssumeRole */
                 external_id?: string;
             };
+            /** @description Enable experimental PGlite support (required to use pglite config or file:///memory:// URLs) */
+            allow_experimental_pglite?: boolean;
             pglite?: true | {
                 /** @description Directory for persistent storage (omit for in-memory) */
                 data_dir?: string;

--- a/apps/service/src/__generated__/openapi.json
+++ b/apps/service/src/__generated__/openapi.json
@@ -1783,6 +1783,24 @@
             "additionalProperties": false,
             "description": "AWS RDS IAM authentication config"
           },
+          "pglite": {
+            "anyOf": [
+              {
+                "type": "boolean",
+                "const": true
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "data_dir": {
+                    "type": "string",
+                    "description": "Directory for persistent storage (omit for in-memory)"
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          },
           "ssl_ca_pem": {
             "type": "string",
             "description": "PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA)"

--- a/apps/service/src/__generated__/openapi.json
+++ b/apps/service/src/__generated__/openapi.json
@@ -1783,6 +1783,10 @@
             "additionalProperties": false,
             "description": "AWS RDS IAM authentication config"
           },
+          "allow_experimental_pglite": {
+            "type": "boolean",
+            "description": "Enable experimental PGlite support (required to use pglite config or file:///memory:// URLs)"
+          },
           "pglite": {
             "anyOf": [
               {

--- a/apps/visualizer/package.json
+++ b/apps/visualizer/package.json
@@ -12,7 +12,7 @@
     "@codemirror/lang-sql": "^6.7.0",
     "@codemirror/state": "^6.4.0",
     "@codemirror/view": "^6.26.0",
-    "@electric-sql/pglite": "^0.2.0",
+    "@electric-sql/pglite": "^0.4.5",
     "@stripe/sync-source-stripe": "workspace:*",
     "codemirror": "^6.0.1",
     "next": "^15",

--- a/examples/browser-sync/index.html
+++ b/examples/browser-sync/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Stripe Sync Engine — Browser</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/browser-sync/package.json
+++ b/examples/browser-sync/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@stripe/sync-example-browser",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@electric-sql/pglite": "^0.4.5",
+    "@stripe/sync-engine": "workspace:*",
+    "@stripe/sync-source-stripe": "workspace:*",
+    "@stripe/sync-destination-postgres": "workspace:*",
+    "@stripe/sync-protocol": "workspace:*",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "@vitejs/plugin-react": "^4",
+    "typescript": "^5",
+    "vite": "^6"
+  }
+}

--- a/examples/browser-sync/package.json
+++ b/examples/browser-sync/package.json
@@ -9,10 +9,10 @@
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.4.5",
-    "@stripe/sync-engine": "workspace:*",
-    "@stripe/sync-source-stripe": "workspace:*",
     "@stripe/sync-destination-postgres": "workspace:*",
+    "@stripe/sync-engine": "workspace:*",
     "@stripe/sync-protocol": "workspace:*",
+    "@stripe/sync-source-stripe": "workspace:*",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
@@ -20,7 +20,12 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^4",
+    "buffer": "^6.0.3",
+    "os-browserify": "^0.3.0",
+    "path-browserify": "^1.0.1",
+    "stream-browserify": "^3.0.0",
     "typescript": "^5",
-    "vite": "^6"
+    "vite": "^6",
+    "vite-plugin-node-polyfills": "^0.26.0"
   }
 }

--- a/examples/browser-sync/src/App.tsx
+++ b/examples/browser-sync/src/App.tsx
@@ -1,0 +1,106 @@
+import { useState, useRef, useCallback } from 'react'
+import { startSync } from './lib/sync'
+
+export default function App() {
+  const [apiKey, setApiKey] = useState('')
+  const [status, setStatus] = useState<'idle' | 'running' | 'error'>('idle')
+  const [messages, setMessages] = useState<string[]>([])
+  const [query, setQuery] = useState('')
+  const [queryResult, setQueryResult] = useState<string>('')
+  const abortRef = useRef<AbortController | null>(null)
+
+  const addMessage = useCallback((msg: string) => {
+    setMessages((prev) => [...prev.slice(-200), msg])
+  }, [])
+
+  const handleStart = async () => {
+    if (!apiKey) return
+    setStatus('running')
+    setMessages([])
+    abortRef.current = new AbortController()
+
+    try {
+      await startSync({
+        apiKey,
+        websocket: true,
+        signal: abortRef.current.signal,
+        onMessage: (msg: unknown) => {
+          const m = msg as { type?: string; record?: { stream?: string } }
+          if (m.type === 'record') {
+            addMessage(`record: ${m.record?.stream}`)
+          } else {
+            addMessage(JSON.stringify(m).slice(0, 120))
+          }
+        },
+      })
+    } catch (err) {
+      if ((err as Error).name !== 'AbortError') {
+        setStatus('error')
+        addMessage(`Error: ${(err as Error).message}`)
+      }
+    }
+  }
+
+  const handleStop = () => {
+    abortRef.current?.abort()
+    setStatus('idle')
+  }
+
+  return (
+    <div style={{ fontFamily: 'monospace', padding: '2rem', maxWidth: '900px', margin: '0 auto' }}>
+      <h1>Stripe Sync Engine — Browser</h1>
+
+      <div style={{ marginBottom: '1rem' }}>
+        <input
+          type="password"
+          placeholder="sk_live_... or sk_test_..."
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          style={{ width: '400px', padding: '0.5rem', fontFamily: 'monospace' }}
+        />
+        {status === 'idle' ? (
+          <button onClick={handleStart} style={{ marginLeft: '0.5rem', padding: '0.5rem 1rem' }}>
+            Start Sync
+          </button>
+        ) : (
+          <button onClick={handleStop} style={{ marginLeft: '0.5rem', padding: '0.5rem 1rem' }}>
+            Stop
+          </button>
+        )}
+        <span style={{ marginLeft: '1rem' }}>{status}</span>
+      </div>
+
+      <div
+        style={{
+          background: '#111',
+          color: '#0f0',
+          padding: '1rem',
+          height: '300px',
+          overflowY: 'auto',
+          fontSize: '12px',
+          marginBottom: '1rem',
+        }}
+      >
+        {messages.map((m, i) => (
+          <div key={i}>{m}</div>
+        ))}
+      </div>
+
+      <div>
+        <textarea
+          placeholder="SELECT * FROM stripe.customers LIMIT 10"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          style={{ width: '100%', height: '60px', fontFamily: 'monospace', padding: '0.5rem' }}
+        />
+        <button
+          onClick={() => setQueryResult('TODO: wire PGlite query')}
+          style={{ padding: '0.5rem 1rem' }}
+        >
+          Run Query
+        </button>
+        {queryResult && <pre style={{ marginTop: '0.5rem' }}>{queryResult}</pre>}
+      </div>
+    </div>
+  )
+}

--- a/examples/browser-sync/src/lib/sync.ts
+++ b/examples/browser-sync/src/lib/sync.ts
@@ -1,0 +1,49 @@
+import { createEngine, createConnectorResolver } from '@stripe/sync-engine'
+import sourceStripe from '@stripe/sync-source-stripe'
+import destinationPostgres from '@stripe/sync-destination-postgres'
+
+export interface SyncOptions {
+  apiKey: string
+  websocket?: boolean
+  onMessage?: (msg: unknown) => void
+  signal?: AbortSignal
+}
+
+export async function startSync({ apiKey, websocket = true, onMessage, signal }: SyncOptions) {
+  const resolver = await createConnectorResolver({
+    sources: { stripe: sourceStripe },
+    destinations: { postgres: destinationPostgres },
+  })
+
+  const engine = createEngine(resolver)
+
+  const pipeline = {
+    source: {
+      type: 'stripe' as const,
+      stripe: {
+        api_key: apiKey,
+        websocket,
+      },
+    },
+    destination: {
+      type: 'postgres' as const,
+      postgres: {
+        url: 'memory://',
+        schema: 'stripe',
+        batch_size: 50,
+      },
+    },
+  }
+
+  // Setup (creates schema + tables)
+  for await (const msg of engine.pipeline_setup(pipeline)) {
+    onMessage?.(msg)
+    if (signal?.aborted) return
+  }
+
+  // Sync (backfill + live)
+  for await (const msg of engine.pipeline_sync(pipeline)) {
+    onMessage?.(msg)
+    if (signal?.aborted) return
+  }
+}

--- a/examples/browser-sync/src/lib/sync.ts
+++ b/examples/browser-sync/src/lib/sync.ts
@@ -1,6 +1,6 @@
-import { createEngine, createConnectorResolver } from '@stripe/sync-engine'
+import { createEngine, createConnectorResolver } from '@stripe/sync-engine/lib'
 import sourceStripe from '@stripe/sync-source-stripe'
-import destinationPostgres from '@stripe/sync-destination-postgres'
+import destinationPostgres from '@stripe/sync-destination-postgres/pglite'
 
 export interface SyncOptions {
   apiKey: string

--- a/examples/browser-sync/src/main.tsx
+++ b/examples/browser-sync/src/main.tsx
@@ -1,0 +1,4 @@
+import { createRoot } from 'react-dom/client'
+import App from './App'
+
+createRoot(document.getElementById('root')!).render(<App />)

--- a/examples/browser-sync/src/shims/child_process.ts
+++ b/examples/browser-sync/src/shims/child_process.ts
@@ -1,0 +1,10 @@
+export function spawn() {
+  throw new Error('child_process.spawn is not available in browser')
+}
+export function exec() {
+  throw new Error('child_process.exec is not available in browser')
+}
+export function execSync() {
+  throw new Error('child_process.execSync is not available in browser')
+}
+export default { spawn, exec, execSync }

--- a/examples/browser-sync/src/shims/crypto.ts
+++ b/examples/browser-sync/src/shims/crypto.ts
@@ -1,0 +1,35 @@
+export function createHash(algorithm: string) {
+  let data = ''
+  return {
+    update(input: string) { data += input; return this },
+    async digest(encoding: string) {
+      const encoder = new TextEncoder()
+      const hashBuffer = await crypto.subtle.digest('SHA-256', encoder.encode(data))
+      const hashArray = Array.from(new Uint8Array(hashBuffer))
+      if (encoding === 'hex') return hashArray.map(b => b.toString(16).padStart(2, '0')).join('')
+      return hashArray
+    },
+  }
+}
+
+export function createHmac(algorithm: string, key: string) {
+  let data = ''
+  return {
+    update(input: string) { data += input; return this },
+    digest(encoding: string) {
+      // Synchronous HMAC not available in browser — return placeholder
+      // This is only used for webhook verification which isn't needed in browser
+      console.warn('createHmac: browser shim — webhook verification disabled')
+      return ''
+    },
+  }
+}
+
+export function timingSafeEqual(a: Uint8Array, b: Uint8Array) {
+  if (a.length !== b.length) return false
+  let result = 0
+  for (let i = 0; i < a.length; i++) result |= a[i]! ^ b[i]!
+  return result === 0
+}
+
+export default { createHash, createHmac, timingSafeEqual }

--- a/examples/browser-sync/src/shims/logger-progress.ts
+++ b/examples/browser-sync/src/shims/logger-progress.ts
@@ -1,0 +1,4 @@
+export function formatProgress() { return '' }
+export function formatProgressHeader() { return '' }
+export function ProgressView() { return null }
+export function ProgressHeader() { return null }

--- a/examples/browser-sync/src/shims/logger.ts
+++ b/examples/browser-sync/src/shims/logger.ts
@@ -1,0 +1,43 @@
+const noop = () => {}
+
+function createChild() {
+  return logger
+}
+
+const logger: any = {
+  info: console.info.bind(console),
+  debug: console.debug.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+  fatal: console.error.bind(console),
+  trace: console.debug.bind(console),
+  child: createChild,
+  level: 'debug',
+  silent: noop,
+  isLevelEnabled: () => true,
+}
+
+export const log = logger
+export type Logger = typeof logger
+export type DestinationStream = any
+export type LoggerOptions = any
+export type RoutedLogLevel = 'debug' | 'info' | 'warn' | 'error'
+export type RoutedLogEntry = { level: RoutedLogLevel; message: string }
+export type LoggerContext = { name?: string; sync_engine_request_id?: string | null }
+
+export const destination = () => ({})
+export function getLoggerContext() { return undefined }
+export function getEngineRequestId() { return null }
+export function runWithLogContext<T>(_patch: unknown, fn: () => T): T { return fn() }
+export function withoutLogCapture<T>(fn: () => T): T { return fn() }
+export function bindLogContext<T>(_patch: unknown, fn: (...args: any[]) => T) { return fn }
+export function createAsyncQueue<T>() {
+  const items: T[] = []
+  return {
+    push: (item: T) => { items.push(item) },
+    wait: async () => items.shift(),
+    [Symbol.asyncIterator]: async function* () { while (true) yield await new Promise<T>(noop) },
+  }
+}
+export function createLogger() { return logger }
+export default logger

--- a/examples/browser-sync/src/shims/node-builtins.ts
+++ b/examples/browser-sync/src/shims/node-builtins.ts
@@ -1,0 +1,13 @@
+// Shims for node:fs, node:fs/promises, node:path, node:os, node:net, node:stream, node:http
+// These are imported by engine code but not exercised in the browser PGlite path
+
+export function readFileSync() { throw new Error('fs not available in browser') }
+export function writeFileSync() { throw new Error('fs not available in browser') }
+export function mkdirSync() { throw new Error('fs not available in browser') }
+export function existsSync() { return false }
+export function openSync() { return -1 }
+export function closeSync() {}
+export async function readFile() { throw new Error('fs not available in browser') }
+export async function writeFile() { throw new Error('fs not available in browser') }
+export async function access() { throw new Error('fs not available in browser') }
+export default { readFileSync, writeFileSync, mkdirSync, existsSync, openSync, closeSync, readFile, writeFile, access, promises: { readFile, writeFile, access } }

--- a/examples/browser-sync/src/shims/noop.ts
+++ b/examples/browser-sync/src/shims/noop.ts
@@ -1,0 +1,2 @@
+export class HttpsProxyAgent {}
+export default {}

--- a/examples/browser-sync/src/shims/pg.ts
+++ b/examples/browser-sync/src/shims/pg.ts
@@ -1,0 +1,6 @@
+// Stub for 'pg' — the PGlite path never actually uses pg.Pool
+const Pool = class {
+  constructor() { throw new Error('pg.Pool is not available in browser — use PGlite') }
+}
+export default { Pool }
+export { Pool }

--- a/examples/browser-sync/src/shims/url.ts
+++ b/examples/browser-sync/src/shims/url.ts
@@ -1,0 +1,8 @@
+export function fileURLToPath(url: string) {
+  return url.replace('file://', '')
+}
+export function pathToFileURL(p: string) {
+  return new URL(`file://${p}`)
+}
+export { URL, URLSearchParams } from 'url'
+export default { fileURLToPath, pathToFileURL, URL, URLSearchParams }

--- a/examples/browser-sync/src/shims/ws.ts
+++ b/examples/browser-sync/src/shims/ws.ts
@@ -1,0 +1,38 @@
+import { EventEmitter } from 'events'
+
+class BrowserWebSocket extends EventEmitter {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+
+  private ws: WebSocket
+
+  get readyState() { return this.ws.readyState }
+
+  constructor(url: string, _opts?: unknown) {
+    super()
+    this.ws = new WebSocket(url)
+
+    this.ws.onopen = () => this.emit('open')
+    this.ws.onclose = (e) => this.emit('close', e.code, e.reason)
+    this.ws.onerror = (e) => this.emit('error', e)
+    this.ws.onmessage = (e) => this.emit('message', e.data)
+  }
+
+  send(data: string | ArrayBuffer) {
+    this.ws.send(data)
+  }
+
+  close(code?: number, reason?: string) {
+    this.ws.close(code, reason)
+  }
+
+  terminate() {
+    this.ws.close()
+  }
+
+  ping() {}
+}
+
+export default BrowserWebSocket

--- a/examples/browser-sync/tsconfig.json
+++ b/examples/browser-sync/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/examples/browser-sync/vite.config.ts
+++ b/examples/browser-sync/vite.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import path from 'path'
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@stripe/sync-logger/progress': path.resolve(__dirname, 'src/shims/logger-progress.ts'),
+      '@stripe/sync-logger': path.resolve(__dirname, 'src/shims/logger.ts'),
+      'pg': path.resolve(__dirname, 'src/shims/pg.ts'),
+      'ws': path.resolve(__dirname, 'src/shims/ws.ts'),
+      'https-proxy-agent': path.resolve(__dirname, 'src/shims/noop.ts'),
+    },
+  },
+  define: {
+    'process.env': '{}',
+    'process.platform': '"browser"',
+  },
+  build: {
+    target: 'esnext',
+  },
+  optimizeDeps: {
+    exclude: ['@electric-sql/pglite'],
+    esbuildOptions: {
+      target: 'esnext',
+    },
+  },
+  server: {
+    proxy: {
+      '/stripe-api': {
+        target: 'https://api.stripe.com',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/stripe-api/, ''),
+      },
+    },
+  },
+})

--- a/examples/browser-sync/vite.config.ts
+++ b/examples/browser-sync/vite.config.ts
@@ -1,15 +1,39 @@
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
 import path from 'path'
 
 const shim = (name: string) => path.resolve(__dirname, `src/shims/${name}.ts`)
 
+// Custom plugin to resolve node: imports that the polyfills plugin misses
+// (linked workspace dist/ files served via /@fs/ bypass the default polyfill resolution)
+function nodeShimPlugin(): Plugin {
+  const nodeShims: Record<string, string> = {
+    'node:child_process': shim('child_process'),
+    'node:fs': shim('node-builtins'),
+    'node:fs/promises': shim('node-builtins'),
+    'node:net': shim('noop'),
+    'node:http': shim('noop'),
+    'node:url': shim('url'),
+  }
+
+  return {
+    name: 'node-shim-resolver',
+    enforce: 'pre',
+    resolveId(source) {
+      if (nodeShims[source]) return nodeShims[source]
+      return null
+    },
+  }
+}
+
 export default defineConfig({
   plugins: [
+    nodeShimPlugin(),
     react(),
     nodePolyfills({
       include: ['buffer', 'crypto', 'stream', 'path', 'os', 'events', 'util', 'process'],
+      globals: { process: true, Buffer: true, global: true },
     }),
   ],
   resolve: {
@@ -19,13 +43,12 @@ export default defineConfig({
       'pg': shim('pg'),
       'ws': shim('ws'),
       'https-proxy-agent': shim('noop'),
-      'node:child_process': shim('child_process'),
-      'node:net': shim('noop'),
-      'node:http': shim('noop'),
     },
   },
   define: {
     'process.platform': '"browser"',
+    'process.env.NODE_DEBUG': '""',
+    'process.env.NODE_ENV': '"development"',
   },
   build: {
     target: 'esnext',

--- a/examples/browser-sync/vite.config.ts
+++ b/examples/browser-sync/vite.config.ts
@@ -1,20 +1,30 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { nodePolyfills } from 'vite-plugin-node-polyfills'
 import path from 'path'
 
+const shim = (name: string) => path.resolve(__dirname, `src/shims/${name}.ts`)
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    nodePolyfills({
+      include: ['buffer', 'crypto', 'stream', 'path', 'os', 'events', 'util', 'process'],
+    }),
+  ],
   resolve: {
     alias: {
-      '@stripe/sync-logger/progress': path.resolve(__dirname, 'src/shims/logger-progress.ts'),
-      '@stripe/sync-logger': path.resolve(__dirname, 'src/shims/logger.ts'),
-      'pg': path.resolve(__dirname, 'src/shims/pg.ts'),
-      'ws': path.resolve(__dirname, 'src/shims/ws.ts'),
-      'https-proxy-agent': path.resolve(__dirname, 'src/shims/noop.ts'),
+      '@stripe/sync-logger/progress': shim('logger-progress'),
+      '@stripe/sync-logger': shim('logger'),
+      'pg': shim('pg'),
+      'ws': shim('ws'),
+      'https-proxy-agent': shim('noop'),
+      'node:child_process': shim('child_process'),
+      'node:net': shim('noop'),
+      'node:http': shim('noop'),
     },
   },
   define: {
-    'process.env': '{}',
     'process.platform': '"browser"',
   },
   build: {

--- a/packages/destination-postgres/package.json
+++ b/packages/destination-postgres/package.json
@@ -30,7 +30,8 @@
   },
   "peerDependencies": {
     "@aws-sdk/client-sts": "^3",
-    "@aws-sdk/rds-signer": "^3"
+    "@aws-sdk/rds-signer": "^3",
+    "@electric-sql/pglite": "^0.2"
   },
   "peerDependenciesMeta": {
     "@aws-sdk/client-sts": {
@@ -38,11 +39,15 @@
     },
     "@aws-sdk/rds-signer": {
       "optional": true
+    },
+    "@electric-sql/pglite": {
+      "optional": true
     }
   },
   "devDependencies": {
     "@aws-sdk/client-sts": "^3.1013.0",
     "@aws-sdk/rds-signer": "^3.1013.0",
+    "@electric-sql/pglite": "^0.2.17",
     "@types/pg": "^8.15.5",
     "vitest": "^3.2.4"
   }

--- a/packages/destination-postgres/package.json
+++ b/packages/destination-postgres/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@aws-sdk/client-sts": "^3",
     "@aws-sdk/rds-signer": "^3",
-    "@electric-sql/pglite": "^0.2"
+    "@electric-sql/pglite": "^0.4.5"
   },
   "peerDependenciesMeta": {
     "@aws-sdk/client-sts": {
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@aws-sdk/client-sts": "^3.1013.0",
     "@aws-sdk/rds-signer": "^3.1013.0",
-    "@electric-sql/pglite": "^0.2.17",
+    "@electric-sql/pglite": "^0.4.5",
     "@types/pg": "^8.15.5",
     "vitest": "^3.2.4"
   }

--- a/packages/destination-postgres/package.json
+++ b/packages/destination-postgres/package.json
@@ -8,6 +8,11 @@
       "bun": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./pglite": {
+      "bun": "./src/pglite-entry.ts",
+      "types": "./dist/pglite-entry.d.ts",
+      "import": "./dist/pglite-entry.js"
     }
   },
   "bin": {

--- a/packages/destination-postgres/src/client-pg.ts
+++ b/packages/destination-postgres/src/client-pg.ts
@@ -1,0 +1,26 @@
+import type pg from 'pg'
+import type { Logger } from '@stripe/sync-logger'
+import { log } from './logger.js'
+import type { ManagedClient } from './client.js'
+
+export function pgPoolClient(pool: pg.Pool, logger: Logger = log): ManagedClient {
+  pool.on('error', (err) => {
+    logger.error({ err }, 'Postgres destination pool error')
+  })
+
+  return {
+    query(text: string, values?: unknown[]) {
+      return pool.query(text, values)
+    },
+    async close() {
+      await pool.end()
+    },
+    stats() {
+      return {
+        total_count: pool.totalCount,
+        idle_count: pool.idleCount,
+        waiting_count: pool.waitingCount,
+      }
+    },
+  }
+}

--- a/packages/destination-postgres/src/client-pglite.ts
+++ b/packages/destination-postgres/src/client-pglite.ts
@@ -13,6 +13,20 @@ export async function pgliteClient(
   const dataSource = config.url ?? config.data_dir
   const db = await PGlite.create(dataSource)
 
+  let closed = false
+  const shutdown = () => {
+    if (closed) return
+    closed = true
+    db.close().catch(() => {})
+    cleanup()
+  }
+  const cleanup = () => {
+    process.removeListener('SIGTERM', shutdown)
+    process.removeListener('SIGINT', shutdown)
+  }
+  process.on('SIGTERM', shutdown)
+  process.on('SIGINT', shutdown)
+
   function adaptResult(result: { rows: unknown[]; affectedRows?: number; fields?: { name: string; dataTypeID: number }[] }): pg.QueryResult {
     return {
       rows: result.rows as Record<string, unknown>[],
@@ -47,6 +61,9 @@ export async function pgliteClient(
       }
     },
     async close() {
+      if (closed) return
+      closed = true
+      cleanup()
       await db.close()
     },
   }

--- a/packages/destination-postgres/src/client-pglite.ts
+++ b/packages/destination-postgres/src/client-pglite.ts
@@ -1,0 +1,53 @@
+import type pg from 'pg'
+import type { ManagedClient } from './client.js'
+
+export function isPGliteUrl(url: string): boolean {
+  return url.startsWith('file://') || url.startsWith('memory://')
+}
+
+export async function pgliteClient(
+  config: { data_dir?: string; url?: string } = {}
+): Promise<ManagedClient> {
+  const { PGlite } = await import('@electric-sql/pglite')
+
+  const dataSource = config.url ?? config.data_dir
+  const db = await PGlite.create(dataSource)
+
+  function adaptResult(result: { rows: unknown[]; affectedRows?: number; fields?: { name: string; dataTypeID: number }[] }): pg.QueryResult {
+    return {
+      rows: result.rows as Record<string, unknown>[],
+      rowCount: result.affectedRows ?? null,
+      command: '',
+      oid: 0,
+      fields: result.fields?.map((f) => ({
+        ...f,
+        tableID: 0,
+        columnID: 0,
+        dataTypeSize: 0,
+        dataTypeModifier: 0,
+        format: 'text' as const,
+      })) ?? [],
+    } as pg.QueryResult
+  }
+
+  return {
+    async query(text: string, values?: unknown[]) {
+      if (values && values.length > 0) {
+        return adaptResult(await db.query(text, values))
+      }
+      // PGlite's query() rejects multiple statements; use exec() as fallback
+      try {
+        return adaptResult(await db.query(text))
+      } catch (err) {
+        if (err instanceof Error && err.message.includes('multiple commands')) {
+          await db.exec(text)
+          return adaptResult({ rows: [], affectedRows: 0, fields: [] })
+        }
+        throw err
+      }
+    },
+    async close() {
+      await db.close()
+    },
+  }
+}

--- a/packages/destination-postgres/src/client.ts
+++ b/packages/destination-postgres/src/client.ts
@@ -33,11 +33,17 @@ export function pgPoolClient(pool: pg.Pool, logger: Logger = log): ManagedClient
   }
 }
 
+export function isPGliteUrl(url: string): boolean {
+  return url.startsWith('file://') || url.startsWith('memory://')
+}
+
 export async function pgliteClient(
-  config: { data_dir?: string } = {}
+  config: { data_dir?: string; url?: string } = {}
 ): Promise<ManagedClient> {
   const { PGlite } = await import('@electric-sql/pglite')
-  const db = await PGlite.create(config.data_dir)
+
+  const dataSource = config.url ?? config.data_dir
+  const db = await PGlite.create(dataSource)
 
   return {
     async query(text: string, values?: unknown[]) {

--- a/packages/destination-postgres/src/client.ts
+++ b/packages/destination-postgres/src/client.ts
@@ -1,0 +1,64 @@
+import type pg from 'pg'
+import type { Logger } from '@stripe/sync-logger'
+import { log } from './logger.js'
+
+export interface QueryClient {
+  query(text: string, values?: unknown[]): Promise<pg.QueryResult>
+}
+
+export interface ManagedClient extends QueryClient {
+  close(): Promise<void>
+  stats?(): { total_count: number; idle_count: number; waiting_count: number }
+}
+
+export function pgPoolClient(pool: pg.Pool, logger: Logger = log): ManagedClient {
+  pool.on('error', (err) => {
+    logger.error({ err }, 'Postgres destination pool error')
+  })
+
+  return {
+    query(text: string, values?: unknown[]) {
+      return pool.query(text, values)
+    },
+    async close() {
+      await pool.end()
+    },
+    stats() {
+      return {
+        total_count: pool.totalCount,
+        idle_count: pool.idleCount,
+        waiting_count: pool.waitingCount,
+      }
+    },
+  }
+}
+
+export async function pgliteClient(
+  config: { data_dir?: string } = {}
+): Promise<ManagedClient> {
+  const { PGlite } = await import('@electric-sql/pglite')
+  const db = await PGlite.create(config.data_dir)
+
+  return {
+    async query(text: string, values?: unknown[]) {
+      const result = await db.query(text, values)
+      return {
+        rows: result.rows as Record<string, unknown>[],
+        rowCount: result.affectedRows ?? null,
+        command: '',
+        oid: 0,
+        fields: result.fields?.map((f) => ({
+          ...f,
+          tableID: 0,
+          columnID: 0,
+          dataTypeSize: 0,
+          dataTypeModifier: 0,
+          format: 'text' as const,
+        })) ?? [],
+      } as pg.QueryResult
+    },
+    async close() {
+      await db.close()
+    },
+  }
+}

--- a/packages/destination-postgres/src/client.ts
+++ b/packages/destination-postgres/src/client.ts
@@ -45,23 +45,38 @@ export async function pgliteClient(
   const dataSource = config.url ?? config.data_dir
   const db = await PGlite.create(dataSource)
 
+  function adaptResult(result: { rows: unknown[]; affectedRows?: number; fields?: { name: string; dataTypeID: number }[] }): pg.QueryResult {
+    return {
+      rows: result.rows as Record<string, unknown>[],
+      rowCount: result.affectedRows ?? null,
+      command: '',
+      oid: 0,
+      fields: result.fields?.map((f) => ({
+        ...f,
+        tableID: 0,
+        columnID: 0,
+        dataTypeSize: 0,
+        dataTypeModifier: 0,
+        format: 'text' as const,
+      })) ?? [],
+    } as pg.QueryResult
+  }
+
   return {
     async query(text: string, values?: unknown[]) {
-      const result = await db.query(text, values)
-      return {
-        rows: result.rows as Record<string, unknown>[],
-        rowCount: result.affectedRows ?? null,
-        command: '',
-        oid: 0,
-        fields: result.fields?.map((f) => ({
-          ...f,
-          tableID: 0,
-          columnID: 0,
-          dataTypeSize: 0,
-          dataTypeModifier: 0,
-          format: 'text' as const,
-        })) ?? [],
-      } as pg.QueryResult
+      if (values && values.length > 0) {
+        return adaptResult(await db.query(text, values))
+      }
+      // PGlite's query() rejects multiple statements; use exec() as fallback
+      try {
+        return adaptResult(await db.query(text))
+      } catch (err) {
+        if (err instanceof Error && err.message.includes('multiple commands')) {
+          await db.exec(text)
+          return adaptResult({ rows: [], affectedRows: 0, fields: [] })
+        }
+        throw err
+      }
     },
     async close() {
       await db.close()

--- a/packages/destination-postgres/src/client.ts
+++ b/packages/destination-postgres/src/client.ts
@@ -1,6 +1,4 @@
 import type pg from 'pg'
-import type { Logger } from '@stripe/sync-logger'
-import { log } from './logger.js'
 
 export interface QueryClient {
   query(text: string, values?: unknown[]): Promise<pg.QueryResult>
@@ -11,75 +9,5 @@ export interface ManagedClient extends QueryClient {
   stats?(): { total_count: number; idle_count: number; waiting_count: number }
 }
 
-export function pgPoolClient(pool: pg.Pool, logger: Logger = log): ManagedClient {
-  pool.on('error', (err) => {
-    logger.error({ err }, 'Postgres destination pool error')
-  })
-
-  return {
-    query(text: string, values?: unknown[]) {
-      return pool.query(text, values)
-    },
-    async close() {
-      await pool.end()
-    },
-    stats() {
-      return {
-        total_count: pool.totalCount,
-        idle_count: pool.idleCount,
-        waiting_count: pool.waitingCount,
-      }
-    },
-  }
-}
-
-export function isPGliteUrl(url: string): boolean {
-  return url.startsWith('file://') || url.startsWith('memory://')
-}
-
-export async function pgliteClient(
-  config: { data_dir?: string; url?: string } = {}
-): Promise<ManagedClient> {
-  const { PGlite } = await import('@electric-sql/pglite')
-
-  const dataSource = config.url ?? config.data_dir
-  const db = await PGlite.create(dataSource)
-
-  function adaptResult(result: { rows: unknown[]; affectedRows?: number; fields?: { name: string; dataTypeID: number }[] }): pg.QueryResult {
-    return {
-      rows: result.rows as Record<string, unknown>[],
-      rowCount: result.affectedRows ?? null,
-      command: '',
-      oid: 0,
-      fields: result.fields?.map((f) => ({
-        ...f,
-        tableID: 0,
-        columnID: 0,
-        dataTypeSize: 0,
-        dataTypeModifier: 0,
-        format: 'text' as const,
-      })) ?? [],
-    } as pg.QueryResult
-  }
-
-  return {
-    async query(text: string, values?: unknown[]) {
-      if (values && values.length > 0) {
-        return adaptResult(await db.query(text, values))
-      }
-      // PGlite's query() rejects multiple statements; use exec() as fallback
-      try {
-        return adaptResult(await db.query(text))
-      } catch (err) {
-        if (err instanceof Error && err.message.includes('multiple commands')) {
-          await db.exec(text)
-          return adaptResult({ rows: [], affectedRows: 0, fields: [] })
-        }
-        throw err
-      }
-    },
-    async close() {
-      await db.close()
-    },
-  }
-}
+export { pgPoolClient } from './client-pg.js'
+export { pgliteClient, isPGliteUrl } from './client-pglite.js'

--- a/packages/destination-postgres/src/index.ts
+++ b/packages/destination-postgres/src/index.ts
@@ -20,10 +20,14 @@ import {
 import defaultSpec from './spec.js'
 import { log } from './logger.js'
 import type { Config } from './spec.js'
+import { pgPoolClient, pgliteClient } from './client.js'
+import type { QueryClient, ManagedClient } from './client.js'
 
 // MARK: - Spec
 
 export { configSchema, type Config } from './spec.js'
+export { pgPoolClient, pgliteClient } from './client.js'
+export type { QueryClient, ManagedClient } from './client.js'
 
 export async function buildPoolConfig(config: Config): Promise<PoolConfig> {
   if (config.aws) {
@@ -80,7 +84,7 @@ export interface WriteManyResult extends UpsertManyResult, DeleteManyResult {}
  * cleaned up — no production user is on the soft-delete code path.
  */
 export async function writeMany(
-  pool: pg.Pool,
+  client: QueryClient,
   schema: string,
   table: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -91,8 +95,8 @@ export async function writeMany(
   const tombstones = entries.filter((e) => e.recordDeleted === true).map((r) => r.data)
   const liveRecords = entries.filter((e) => e.recordDeleted !== true).map((r) => r.data)
 
-  const u = await upsertMany(pool, schema, table, liveRecords, primaryKeyColumns, newerThanField)
-  const d = await deleteMany(pool, schema, table, tombstones, primaryKeyColumns)
+  const u = await upsertMany(client, schema, table, liveRecords, primaryKeyColumns, newerThanField)
+  const d = await deleteMany(client, schema, table, tombstones, primaryKeyColumns)
 
   return { ...u, deleted_count: d.deleted_count }
 }
@@ -102,7 +106,7 @@ export async function writeMany(
  * `_synced_at` is the destination write time.
  */
 export async function upsertMany(
-  pool: pg.Pool,
+  client: QueryClient,
   schema: string,
   table: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -128,7 +132,7 @@ export async function upsertMany(
     return { _raw_data: e, _synced_at: syncedAt, _updated_at: new Date(ts * 1000).toISOString() }
   })
 
-  return await upsertWithStats(pool, records, {
+  return await upsertWithStats(client, records, {
     schema,
     table,
     primaryKeyColumns,
@@ -141,7 +145,7 @@ export async function upsertMany(
  * terminal — once an object is deleted it cannot be undeleted.
  */
 export async function deleteMany(
-  pool: pg.Pool,
+  client: QueryClient,
   schema: string,
   table: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -165,7 +169,7 @@ export async function deleteMany(
 USING (VALUES ${valueRows.join(', ')}) AS d(${identList(primaryKeyColumns)})
 WHERE ${pkJoin}`
 
-  const result = await pool.query(stmt, params)
+  const result = await client.query(stmt, params)
   return { deleted_count: result.rowCount ?? 0 }
 }
 
@@ -187,7 +191,7 @@ export {
 
 /** Throw if any stream's catalog enum allow-list disagrees with an existing CHECK constraint. */
 async function assertEnumConstraintsConsistent(
-  pool: pg.Pool,
+  client: QueryClient,
   schema: string,
   streams: ReadonlyArray<{ stream: { name: string; json_schema?: Record<string, unknown> } }>
 ): Promise<void> {
@@ -203,7 +207,7 @@ async function assertEnumConstraintsConsistent(
   if (enumColumns.size === 0) return
 
   const existing = await getExistingEnumAllowLists(
-    pool,
+    client,
     schema,
     streams.map((s) => s.stream.name),
     [...enumColumns]
@@ -236,23 +240,6 @@ function errorMessage(err: unknown): string {
   return (err as NodeJS.ErrnoException).code ?? err.constructor.name
 }
 
-function createPool(config: PoolConfig): pg.Pool {
-  const pool = new pg.Pool(config)
-  // Destination connectors should surface pool failures without crashing the host process.
-  pool.on('error', (err) => {
-    log.error({ err }, 'Postgres destination pool error')
-  })
-  return pool
-}
-
-function poolStats(pool: pg.Pool) {
-  return {
-    total_count: pool.totalCount,
-    idle_count: pool.idleCount,
-    waiting_count: pool.waitingCount,
-  }
-}
-
 function describePoolConfig(config: PoolConfig) {
   return {
     host: config.host,
@@ -269,7 +256,19 @@ function describePoolConfig(config: PoolConfig) {
   }
 }
 
-async function createInstrumentedPool(config: Config, operation: string): Promise<pg.Pool> {
+async function createManagedClient(config: Config, operation: string): Promise<ManagedClient> {
+  if (config.pglite) {
+    const dataDir = config.pglite === true ? undefined : config.pglite.data_dir
+    log.debug({ operation, data_dir: dataDir }, 'dest postgres: creating PGlite client')
+    const startedAt = Date.now()
+    const client = await pgliteClient({ data_dir: dataDir })
+    log.debug(
+      { operation, duration_ms: Date.now() - startedAt },
+      'dest postgres: PGlite client ready'
+    )
+    return client
+  }
+
   const configStartedAt = Date.now()
   log.debug({ operation }, 'dest postgres: building pool config')
   const poolConfig = await buildPoolConfig(config)
@@ -282,35 +281,27 @@ async function createInstrumentedPool(config: Config, operation: string): Promis
     'dest postgres: built pool config'
   )
 
-  const pool = withQueryLogging(createPool(poolConfig), log)
-  log.debug({ operation, ...poolStats(pool) }, 'dest postgres: pool created')
-  return pool
+  const pool = withQueryLogging(new pg.Pool(poolConfig), log)
+  const client = pgPoolClient(pool, log)
+  log.debug({ operation, ...client.stats?.() }, 'dest postgres: pool created')
+  return client
 }
 
-async function connectAndRelease(pool: pg.Pool, operation: string): Promise<void> {
+async function verifyConnectivity(client: ManagedClient, operation: string): Promise<void> {
   const startedAt = Date.now()
-  log.debug({ operation, ...poolStats(pool) }, 'dest postgres: pool.connect start')
-  const client = await pool.connect()
-  try {
-    log.debug(
-      {
-        operation,
-        duration_ms: Date.now() - startedAt,
-        ...poolStats(pool),
-      },
-      'dest postgres: pool.connect complete'
-    )
-  } finally {
-    client.release()
-    log.debug({ operation, ...poolStats(pool) }, 'dest postgres: pool.connect released')
-  }
+  log.debug({ operation, ...client.stats?.() }, 'dest postgres: connectivity check start')
+  await client.query('SELECT 1')
+  log.debug(
+    { operation, duration_ms: Date.now() - startedAt, ...client.stats?.() },
+    'dest postgres: connectivity check complete'
+  )
 }
 
-async function endPool(pool: pg.Pool, operation: string): Promise<void> {
+async function closeClient(client: ManagedClient, operation: string): Promise<void> {
   const startedAt = Date.now()
-  log.debug({ operation, ...poolStats(pool) }, 'dest postgres: pool.end start')
-  await pool.end()
-  log.debug({ operation, duration_ms: Date.now() - startedAt }, 'dest postgres: pool.end complete')
+  log.debug({ operation, ...client.stats?.() }, 'dest postgres: closing client')
+  await client.close()
+  log.debug({ operation, duration_ms: Date.now() - startedAt }, 'dest postgres: client closed')
 }
 
 const destination = {
@@ -319,10 +310,9 @@ const destination = {
   },
 
   async *check({ config }) {
-    const pool = await createInstrumentedPool(config, 'check')
+    const client = await createManagedClient(config, 'check')
     try {
-      await connectAndRelease(pool, 'check')
-      await pool.query('SELECT 1')
+      await verifyConnectivity(client, 'check')
       yield {
         type: 'connection_status' as const,
         connection_status: { status: 'succeeded' as const },
@@ -336,40 +326,35 @@ const destination = {
         },
       }
     } finally {
-      await endPool(pool, 'check')
+      await closeClient(client, 'check')
     }
   },
 
   async *setup({ config, catalog }) {
-    log.debug({ schema: config.schema }, 'dest setup: connecting to pool')
-    const pool = await createInstrumentedPool(config, 'setup')
+    log.debug({ schema: config.schema }, 'dest setup: creating client')
+    const client = await createManagedClient(config, 'setup')
     try {
-      await connectAndRelease(pool, 'setup')
+      await verifyConnectivity(client, 'setup')
       log.info(`Creating schema "${config.schema}" (${catalog.streams.length} streams)`)
       log.debug('dest setup: creating schema')
-      await pool.query(sql`CREATE SCHEMA IF NOT EXISTS "${config.schema}"`)
-      // Backward-compat: drop legacy `set_updated_at()` (CASCADE removes any orphan `handle_updated_at` triggers from older deployments).
+      await client.query(sql`CREATE SCHEMA IF NOT EXISTS "${config.schema}"`)
       log.debug('dest setup: dropping legacy set_updated_at() function')
-      await pool.query(sql`DROP FUNCTION IF EXISTS "${config.schema}".set_updated_at() CASCADE`)
+      await client.query(sql`DROP FUNCTION IF EXISTS "${config.schema}".set_updated_at() CASCADE`)
 
-      // The DO $check$ block uses ADD CONSTRAINT + EXCEPTION WHEN duplicate_object,
-      // which silently no-ops on a changed enum list — surface it loudly instead.
-      await assertEnumConstraintsConsistent(pool, config.schema, catalog.streams)
+      await assertEnumConstraintsConsistent(client, config.schema, catalog.streams)
 
       log.debug({ streamCount: catalog.streams.length }, 'dest setup: creating tables')
-      await Promise.all(
-        catalog.streams.map(async (cs) => {
-          await pool.query(
-            buildCreateTableDDL(config.schema, cs.stream.name, cs.stream.json_schema ?? {}, {
-              system_columns: cs.system_columns,
-              primary_key: cs.stream.primary_key,
-            })
-          )
-        })
-      )
+      for (const cs of catalog.streams) {
+        await client.query(
+          buildCreateTableDDL(config.schema, cs.stream.name, cs.stream.json_schema ?? {}, {
+            system_columns: cs.system_columns,
+            primary_key: cs.stream.primary_key,
+          })
+        )
+      }
       log.debug('dest setup: complete')
     } finally {
-      await endPool(pool, 'setup')
+      await closeClient(client, 'setup')
     }
   },
 
@@ -380,17 +365,17 @@ const destination = {
         `Refusing to drop protected schema "${config.schema}" — teardown only drops user-created schemas`
       )
     }
-    const pool = await createInstrumentedPool(config, 'teardown')
+    const client = await createManagedClient(config, 'teardown')
     try {
-      await connectAndRelease(pool, 'teardown')
-      await pool.query(sql`DROP SCHEMA IF EXISTS "${config.schema}" CASCADE`)
+      await verifyConnectivity(client, 'teardown')
+      await client.query(sql`DROP SCHEMA IF EXISTS "${config.schema}" CASCADE`)
     } finally {
-      await endPool(pool, 'teardown')
+      await closeClient(client, 'teardown')
     }
   },
 
   async *write({ config, catalog }, $stdin) {
-    const pool = await createInstrumentedPool(config, 'write')
+    const client = await createManagedClient(config, 'write')
     const batchSize = config.batch_size
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const streamBuffers = new Map<string, Record<string, any>[]>()
@@ -406,7 +391,6 @@ const destination = {
 
     const failedStreams = new Set<string>()
 
-    /** Flush and return error message if failed, undefined if ok. */
     const flushStream = async (streamName: string): Promise<string | undefined> => {
       if (failedStreams.has(streamName)) return undefined
       const buffer = streamBuffers.get(streamName)
@@ -421,12 +405,12 @@ const destination = {
           schema: config.schema,
           primary_key: pk,
           newer_than_field: newerThan,
-          ...poolStats(pool),
+          ...client.stats?.(),
         },
         'dest write: flush start'
       )
       try {
-        const stats = await writeMany(pool, config.schema, streamName, buffer, pk, newerThan)
+        const stats = await writeMany(client, config.schema, streamName, buffer, pk, newerThan)
         log.debug(
           {
             stream: streamName,
@@ -438,7 +422,7 @@ const destination = {
             deleted: stats.deleted_count,
             skipped: stats.skipped_count,
             duration_ms: Date.now() - startedAt,
-            ...poolStats(pool),
+            ...client.stats?.(),
           },
           `dest write: upsert ${config.schema}.${streamName}`
         )
@@ -455,7 +439,7 @@ const destination = {
             duration_ms: Date.now() - startedAt,
             error: errMsg,
             err,
-            ...poolStats(pool),
+            ...client.stats?.(),
           },
           'dest write: flush failed'
         )
@@ -475,7 +459,7 @@ const destination = {
     }
 
     try {
-      await connectAndRelease(pool, 'write')
+      await verifyConnectivity(client, 'write')
       for await (const msg of $stdin) {
         if (msg.type === 'record') {
           const { stream } = msg.record
@@ -548,7 +532,7 @@ const destination = {
         log.debug(`Postgres destination: wrote to schema "${config.schema}"`)
       }
     } finally {
-      await endPool(pool, 'write')
+      await closeClient(client, 'write')
     }
   },
 } satisfies Destination<Config>

--- a/packages/destination-postgres/src/index.ts
+++ b/packages/destination-postgres/src/index.ts
@@ -20,13 +20,13 @@ import {
 import defaultSpec from './spec.js'
 import { log } from './logger.js'
 import type { Config } from './spec.js'
-import { pgPoolClient, pgliteClient } from './client.js'
+import { pgPoolClient, pgliteClient, isPGliteUrl } from './client.js'
 import type { QueryClient, ManagedClient } from './client.js'
 
 // MARK: - Spec
 
 export { configSchema, type Config } from './spec.js'
-export { pgPoolClient, pgliteClient } from './client.js'
+export { pgPoolClient, pgliteClient, isPGliteUrl } from './client.js'
 export type { QueryClient, ManagedClient } from './client.js'
 
 export async function buildPoolConfig(config: Config): Promise<PoolConfig> {
@@ -257,11 +257,13 @@ function describePoolConfig(config: PoolConfig) {
 }
 
 async function createManagedClient(config: Config, operation: string): Promise<ManagedClient> {
-  if (config.pglite) {
-    const dataDir = config.pglite === true ? undefined : config.pglite.data_dir
-    log.debug({ operation, data_dir: dataDir }, 'dest postgres: creating PGlite client')
+  const connectionUrl = config.url ?? config.connection_string
+  if (config.pglite || (connectionUrl && isPGliteUrl(connectionUrl))) {
+    const url = connectionUrl && isPGliteUrl(connectionUrl) ? connectionUrl : undefined
+    const dataDir = config.pglite && config.pglite !== true ? config.pglite.data_dir : undefined
+    log.debug({ operation, url, data_dir: dataDir }, 'dest postgres: creating PGlite client')
     const startedAt = Date.now()
-    const client = await pgliteClient({ data_dir: dataDir })
+    const client = await pgliteClient({ url, data_dir: dataDir })
     log.debug(
       { operation, duration_ms: Date.now() - startedAt },
       'dest postgres: PGlite client ready'

--- a/packages/destination-postgres/src/pglite-entry.ts
+++ b/packages/destination-postgres/src/pglite-entry.ts
@@ -1,0 +1,243 @@
+import type { Destination } from '@stripe/sync-protocol'
+import { ident, identList, qualifiedTable, sql } from '@stripe/sync-util-postgres/sql'
+import { upsertWithStats } from '@stripe/sync-util-postgres/upsert'
+import { buildCreateTableDDL, getExistingEnumAllowLists, enumCheckConstraintName } from './schemaProjection.js'
+import defaultSpec from './spec.js'
+import { log } from './logger.js'
+import type { Config } from './spec.js'
+import { pgliteClient, isPGliteUrl } from './client-pglite.js'
+import type { QueryClient, ManagedClient } from './client.js'
+
+export { configSchema, type Config } from './spec.js'
+export { pgliteClient, isPGliteUrl } from './client-pglite.js'
+export type { QueryClient, ManagedClient } from './client.js'
+export { buildCreateTableDDL } from './schemaProjection.js'
+
+export interface UpsertManyResult {
+  created_count: number
+  updated_count: number
+  skipped_count: number
+}
+
+export interface DeleteManyResult {
+  deleted_count: number
+}
+
+export interface WriteManyResult extends UpsertManyResult, DeleteManyResult {}
+
+export async function writeMany(
+  client: QueryClient,
+  schema: string,
+  table: string,
+  entries: Record<string, any>[],
+  primaryKeyColumns: string[] = ['id'],
+  newerThanField: string
+): Promise<WriteManyResult> {
+  const tombstones = entries.filter((e) => e.recordDeleted === true).map((r) => r.data)
+  const liveRecords = entries.filter((e) => e.recordDeleted !== true).map((r) => r.data)
+  const u = await upsertMany(client, schema, table, liveRecords, primaryKeyColumns, newerThanField)
+  const d = await deleteMany(client, schema, table, tombstones, primaryKeyColumns)
+  return { ...u, deleted_count: d.deleted_count }
+}
+
+export async function upsertMany(
+  client: QueryClient,
+  schema: string,
+  table: string,
+  entries: Record<string, any>[],
+  primaryKeyColumns: string[] = ['id'],
+  newerThanField: string
+): Promise<UpsertManyResult> {
+  if (!entries.length) return { created_count: 0, updated_count: 0, skipped_count: 0 }
+  const syncedAt = new Date().toISOString()
+  const records = entries.map((e) => {
+    const ts = e[newerThanField] as unknown
+    if (typeof ts !== 'number' || !Number.isFinite(ts)) {
+      throw new Error(
+        `upsertMany: record missing source-stamped "${newerThanField}" (table=${schema}.${table}, id=${String(e.id)})`
+      )
+    }
+    return { _raw_data: e, _synced_at: syncedAt, _updated_at: new Date(ts * 1000).toISOString() }
+  })
+  return await upsertWithStats(client, records, { schema, table, primaryKeyColumns, newerThanColumn: newerThanField })
+}
+
+export async function deleteMany(
+  client: QueryClient,
+  schema: string,
+  table: string,
+  entries: Record<string, any>[],
+  primaryKeyColumns: string[] = ['id']
+): Promise<DeleteManyResult> {
+  if (!entries.length) return { deleted_count: 0 }
+  const params: unknown[] = []
+  const valueRows = entries.map((e) => {
+    const cells = primaryKeyColumns.map((pk) => {
+      params.push(String(e[pk]))
+      return `$${params.length}::text`
+    })
+    return `(${cells.join(', ')})`
+  })
+  const tbl = qualifiedTable(schema, table)
+  const pkJoin = primaryKeyColumns.map((c) => `t.${ident(c)} = d.${ident(c)}`).join(' AND ')
+  const stmt = `DELETE FROM ${tbl} t\nUSING (VALUES ${valueRows.join(', ')}) AS d(${identList(primaryKeyColumns)})\nWHERE ${pkJoin}`
+  const result = await client.query(stmt, params)
+  return { deleted_count: result.rowCount ?? 0 }
+}
+
+async function assertEnumConstraintsConsistent(
+  client: QueryClient,
+  schema: string,
+  streams: ReadonlyArray<{ stream: { name: string; json_schema?: Record<string, unknown> } }>
+): Promise<void> {
+  const enumColumns = new Set<string>()
+  for (const { stream } of streams) {
+    const props = stream.json_schema?.properties as Record<string, { enum?: string[] }> | undefined
+    if (!props) continue
+    for (const [col, prop] of Object.entries(props)) {
+      if (Array.isArray(prop?.enum) && prop.enum.length > 0) enumColumns.add(col)
+    }
+  }
+  if (enumColumns.size === 0) return
+  const existing = await getExistingEnumAllowLists(client, schema, streams.map((s) => s.stream.name), [...enumColumns])
+  for (const { stream } of streams) {
+    const tableConstraints = existing.get(stream.name)
+    if (!tableConstraints) continue
+    const props = stream.json_schema?.properties as Record<string, { enum?: string[] }> | undefined
+    if (!props) continue
+    for (const [col, existingVals] of tableConstraints) {
+      const newVals = new Set(props[col]?.enum ?? [])
+      if (newVals.size === 0) continue
+      if (existingVals.size === newVals.size && [...existingVals].every((v) => newVals.has(v))) continue
+      const c = enumCheckConstraintName(stream.name, col)
+      const fmt = (s: Set<string>) => [...s].sort().join(', ')
+      throw new Error(
+        `Enum values changed for "${schema}"."${stream.name}"."${col}". ` +
+        `Existing CHECK "${c}" allows [${fmt(existingVals)}]; new catalog wants [${fmt(newVals)}]. ` +
+        `Drop manually: ALTER TABLE "${schema}"."${stream.name}" DROP CONSTRAINT "${c}";`
+      )
+    }
+  }
+}
+
+async function createClient(config: Config): Promise<ManagedClient> {
+  const url = config.url ?? config.connection_string
+  if (config.pglite || (url && isPGliteUrl(url))) {
+    const pgliteUrl = url && isPGliteUrl(url) ? url : undefined
+    const dataDir = config.pglite && config.pglite !== true ? config.pglite.data_dir : undefined
+    return pgliteClient({ url: pgliteUrl, data_dir: dataDir })
+  }
+  throw new Error('PGlite-only destination: url must be memory:// or file://')
+}
+
+const destination = {
+  async *spec() {
+    yield { type: 'spec' as const, spec: defaultSpec }
+  },
+
+  async *check({ config }) {
+    const client = await createClient(config)
+    try {
+      await client.query('SELECT 1')
+      yield { type: 'connection_status' as const, connection_status: { status: 'succeeded' as const } }
+    } catch (err) {
+      yield { type: 'connection_status' as const, connection_status: { status: 'failed' as const, message: err instanceof Error ? err.message : String(err) } }
+    } finally {
+      await client.close()
+    }
+  },
+
+  async *setup({ config, catalog }) {
+    const client = await createClient(config)
+    try {
+      await client.query(sql`CREATE SCHEMA IF NOT EXISTS "${config.schema}"`)
+      await client.query(sql`DROP FUNCTION IF EXISTS "${config.schema}".set_updated_at() CASCADE`)
+      await assertEnumConstraintsConsistent(client, config.schema, catalog.streams)
+      for (const cs of catalog.streams) {
+        await client.query(
+          buildCreateTableDDL(config.schema, cs.stream.name, cs.stream.json_schema ?? {}, {
+            system_columns: cs.system_columns,
+            primary_key: cs.stream.primary_key,
+          })
+        )
+      }
+    } finally {
+      await client.close()
+    }
+  },
+
+  async *teardown({ config }) {
+    const client = await createClient(config)
+    try {
+      await client.query(sql`DROP SCHEMA IF EXISTS "${config.schema}" CASCADE`)
+    } finally {
+      await client.close()
+    }
+  },
+
+  async *write({ config, catalog }, $stdin) {
+    const client = await createClient(config)
+    const batchSize = config.batch_size
+    const streamBuffers = new Map<string, Record<string, any>[]>()
+    const streamKeyColumns = new Map(catalog.streams.map((cs) => [cs.stream.name, cs.stream.primary_key?.map((pk) => pk[0]) ?? ['id']]))
+    const streamNewerThanField = new Map(catalog.streams.map((cs) => [cs.stream.name, cs.stream.newer_than_field]))
+    const failedStreams = new Set<string>()
+
+    const flushStream = async (streamName: string): Promise<string | undefined> => {
+      if (failedStreams.has(streamName)) return undefined
+      const buffer = streamBuffers.get(streamName)
+      if (!buffer || buffer.length === 0) return undefined
+      const pk = streamKeyColumns.get(streamName) ?? ['id']
+      const newerThan = streamNewerThanField.get(streamName)!
+      try {
+        await writeMany(client, config.schema, streamName, buffer, pk, newerThan)
+      } catch (err) {
+        failedStreams.add(streamName)
+        streamBuffers.set(streamName, [])
+        return err instanceof Error ? err.message : String(err)
+      }
+      streamBuffers.set(streamName, [])
+      return undefined
+    }
+
+    function streamError(stream: string, error: string) {
+      return { type: 'stream_status' as const, stream_status: { stream, status: 'error' as const, error } }
+    }
+
+    try {
+      await client.query('SELECT 1')
+      for await (const msg of $stdin) {
+        if (msg.type === 'record') {
+          const { stream } = msg.record
+          if (failedStreams.has(stream)) continue
+          if (!streamBuffers.has(stream)) streamBuffers.set(stream, [])
+          const buffer = streamBuffers.get(stream)!
+          buffer.push(msg.record as Record<string, unknown>)
+          if (buffer.length >= batchSize) {
+            const err = await flushStream(stream)
+            if (err) { yield streamError(stream, err); continue }
+          }
+          yield msg
+        } else if (msg.type === 'source_state') {
+          if (msg.source_state.state_type !== 'global') {
+            const stream = msg.source_state.stream
+            if (failedStreams.has(stream)) continue
+            const err = await flushStream(stream)
+            if (err) { yield streamError(stream, err); continue }
+          }
+          yield msg
+        } else {
+          yield msg
+        }
+      }
+      for (const streamName of streamBuffers.keys()) {
+        const err = await flushStream(streamName)
+        if (err) yield streamError(streamName, err)
+      }
+    } finally {
+      await client.close()
+    }
+  },
+} satisfies Destination<Config>
+
+export default destination

--- a/packages/destination-postgres/src/pglite.test.ts
+++ b/packages/destination-postgres/src/pglite.test.ts
@@ -12,7 +12,7 @@ const SCHEMA = 'test_dest'
 let dataDir: string
 
 function makeConfig(): Config {
-  return { pglite: { data_dir: dataDir }, schema: SCHEMA, batch_size: 100 }
+  return { pglite: { data_dir: dataDir }, schema: SCHEMA, batch_size: 100, allow_experimental_pglite: true }
 }
 
 beforeAll(() => {

--- a/packages/destination-postgres/src/pglite.test.ts
+++ b/packages/destination-postgres/src/pglite.test.ts
@@ -1,0 +1,244 @@
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import destination, { deleteMany, upsertMany, writeMany, pgliteClient } from './index.js'
+import type { ManagedClient } from './client.js'
+import type { ConfiguredCatalog, DestinationInput, DestinationOutput } from '@stripe/sync-protocol'
+import { collectFirst, drain } from '@stripe/sync-protocol'
+import type { Config } from './spec.js'
+
+const SCHEMA = 'test_dest'
+let dataDir: string
+
+function makeConfig(): Config {
+  return { pglite: { data_dir: dataDir }, schema: SCHEMA, batch_size: 100 }
+}
+
+beforeAll(() => {
+  dataDir = mkdtempSync(join(tmpdir(), 'pglite-test-'))
+})
+
+afterAll(() => {
+  rmSync(dataDir, { recursive: true, force: true })
+})
+
+let nextRecordTs = Math.floor(Date.now() / 1000)
+function makeRecord(stream: string, data: Record<string, unknown>) {
+  return {
+    type: 'record' as const,
+    record: {
+      stream,
+      data: { _updated_at: nextRecordTs++, ...data },
+      emitted_at: new Date().toISOString(),
+    },
+  }
+}
+
+function makeState(stream: string, data: unknown) {
+  return { type: 'source_state' as const, source_state: { stream, data } }
+}
+
+async function* toAsyncIter(msgs: DestinationInput[]): AsyncIterable<DestinationInput> {
+  for (const msg of msgs) yield msg
+}
+
+async function collectOutputs(iter: AsyncIterable<DestinationOutput>): Promise<DestinationOutput[]> {
+  const results: DestinationOutput[] = []
+  for await (const msg of iter) results.push(msg)
+  return results
+}
+
+async function resetSchema() {
+  const c = await pgliteClient({ data_dir: dataDir })
+  await c.query(`DROP SCHEMA IF EXISTS "${SCHEMA}" CASCADE`)
+  await c.close()
+}
+
+const catalog: ConfiguredCatalog = {
+  streams: [
+    {
+      stream: {
+        name: 'customer',
+        primary_key: [['id']],
+        newer_than_field: '_updated_at',
+        metadata: {},
+      },
+      sync_mode: 'full_refresh',
+      destination_sync_mode: 'overwrite',
+    },
+  ],
+}
+
+describe('PGlite destination', () => {
+  beforeEach(async () => {
+    await resetSchema()
+  })
+
+  describe('check()', () => {
+    it('succeeds with pglite config', async () => {
+      const statusMsg = await collectFirst(
+        destination.check({ config: makeConfig() }),
+        'connection_status'
+      )
+      expect(statusMsg.connection_status.status).toBe('succeeded')
+    })
+  })
+
+  describe('setup()', () => {
+    it('creates schema and table', async () => {
+      await drain(destination.setup!({ config: makeConfig(), catalog }))
+
+      const c = await pgliteClient({ data_dir: dataDir })
+      try {
+        const { rows } = await c.query(
+          `SELECT table_name FROM information_schema.tables WHERE table_schema = $1`,
+          [SCHEMA]
+        )
+        expect(rows.map((r) => r.table_name)).toContain('customer')
+      } finally {
+        await c.close()
+      }
+    })
+  })
+
+  describe('write()', () => {
+    beforeEach(async () => {
+      await drain(destination.setup!({ config: makeConfig(), catalog }))
+    })
+
+    it('upserts records via PGlite', async () => {
+      const messages = toAsyncIter([
+        makeRecord('customer', { id: 'cus_1', name: 'Alice' }),
+        makeRecord('customer', { id: 'cus_2', name: 'Bob' }),
+      ])
+
+      const outputs = await collectOutputs(destination.write({ config: makeConfig(), catalog }, messages))
+      const records = outputs.filter((m) => m.type === 'record')
+      expect(records).toHaveLength(2)
+    })
+
+    it('re-emits SourceStateMessage after flushing', async () => {
+      const stateData = { cursor: 'abc123' }
+      const messages = toAsyncIter([
+        makeRecord('customer', { id: 'cus_1', name: 'Alice' }),
+        makeState('customer', stateData),
+      ])
+
+      const outputs = await collectOutputs(destination.write({ config: makeConfig(), catalog }, messages))
+      const stateOutputs = outputs.filter((m) => m.type === 'source_state')
+      expect(stateOutputs).toHaveLength(1)
+      expect(stateOutputs[0]).toEqual({
+        type: 'source_state',
+        source_state: { stream: 'customer', data: stateData },
+      })
+    })
+
+    it('handles upsert (ON CONFLICT update)', async () => {
+      const messages1 = toAsyncIter([makeRecord('customer', { id: 'cus_1', name: 'Alice' })])
+      await collectOutputs(destination.write({ config: makeConfig(), catalog }, messages1))
+
+      const messages2 = toAsyncIter([makeRecord('customer', { id: 'cus_1', name: 'Alice Updated' })])
+      await collectOutputs(destination.write({ config: makeConfig(), catalog }, messages2))
+
+      const c = await pgliteClient({ data_dir: dataDir })
+      try {
+        const { rows } = await c.query(
+          `SELECT _raw_data->>'name' AS name FROM "${SCHEMA}".customer WHERE id = 'cus_1'`
+        )
+        expect(rows[0].name).toBe('Alice Updated')
+      } finally {
+        await c.close()
+      }
+    })
+  })
+})
+
+describe('PGlite upsertMany / deleteMany / writeMany', () => {
+  let client: ManagedClient
+
+  beforeEach(async () => {
+    client = await pgliteClient({ data_dir: dataDir })
+    await client.query(`DROP SCHEMA IF EXISTS "${SCHEMA}" CASCADE`)
+    await client.query(`CREATE SCHEMA IF NOT EXISTS "${SCHEMA}"`)
+    await client.query(`CREATE TABLE IF NOT EXISTS "${SCHEMA}".customer (
+      "_raw_data" jsonb NOT NULL,
+      "_synced_at" timestamptz NOT NULL DEFAULT now(),
+      "_updated_at" timestamptz NOT NULL DEFAULT now(),
+      "id" text GENERATED ALWAYS AS ((_raw_data->>'id')::text) STORED,
+      PRIMARY KEY ("id")
+    )`)
+  })
+
+  afterEach(async () => {
+    await client?.close()
+  })
+
+  it('upsertMany inserts records', async () => {
+    const ts = Math.floor(Date.now() / 1000)
+    await upsertMany(
+      client,
+      SCHEMA,
+      'customer',
+      [
+        { id: 'cus_10', name: 'Direct', _updated_at: ts },
+        { id: 'cus_11', name: 'Insert', _updated_at: ts },
+      ],
+      ['id'],
+      '_updated_at'
+    )
+
+    const { rows } = await client.query(`SELECT count(*)::int AS n FROM "${SCHEMA}".customer`)
+    expect(rows[0].n).toBe(2)
+  })
+
+  it('deleteMany removes rows', async () => {
+    const ts = Math.floor(Date.now() / 1000)
+    await upsertMany(
+      client,
+      SCHEMA,
+      'customer',
+      [
+        { id: 'cus_keep', name: 'Keep', _updated_at: ts },
+        { id: 'cus_drop', name: 'Drop', _updated_at: ts },
+      ],
+      ['id'],
+      '_updated_at'
+    )
+
+    const result = await deleteMany(client, SCHEMA, 'customer', [{ id: 'cus_drop' }], ['id'])
+    expect(result.deleted_count).toBe(1)
+
+    const { rows } = await client.query(`SELECT id FROM "${SCHEMA}".customer ORDER BY id`)
+    expect(rows).toEqual([{ id: 'cus_keep' }])
+  })
+
+  it('writeMany routes mixed batch to upsert and delete', async () => {
+    const ts = Math.floor(Date.now() / 1000)
+    await upsertMany(
+      client,
+      SCHEMA,
+      'customer',
+      [{ id: 'cus_old', name: 'Old', _updated_at: ts }],
+      ['id'],
+      '_updated_at'
+    )
+
+    const result = await writeMany(
+      client,
+      SCHEMA,
+      'customer',
+      [
+        { data: { id: 'cus_new', name: 'New', _updated_at: ts + 1 } },
+        { recordDeleted: true, data: { id: 'cus_old', _updated_at: ts + 1 } },
+      ],
+      ['id'],
+      '_updated_at'
+    )
+    expect(result.created_count).toBe(1)
+    expect(result.deleted_count).toBe(1)
+
+    const { rows } = await client.query(`SELECT id FROM "${SCHEMA}".customer ORDER BY id`)
+    expect(rows).toEqual([{ id: 'cus_new' }])
+  })
+})

--- a/packages/destination-postgres/src/spec.ts
+++ b/packages/destination-postgres/src/spec.ts
@@ -19,6 +19,15 @@ export const configSchema = z
       })
       .optional()
       .describe('AWS RDS IAM authentication config'),
+    pglite: z
+      .union([
+        z.literal(true),
+        z.object({
+          data_dir: z.string().optional().describe('Directory for persistent storage (omit for in-memory)'),
+        }),
+      ])
+      .optional()
+      .describe('Use PGlite (in-process WASM Postgres) instead of connecting to an external server'),
     ssl_ca_pem: z
       .string()
       .optional()
@@ -29,6 +38,10 @@ export const configSchema = z
   .refine((config) => !((config.url || config.connection_string) && config.aws), {
     message: 'Specify either url/connection_string or aws config, not both',
     path: ['aws'],
+  })
+  .refine((config) => !(config.pglite && (config.url || config.connection_string || config.aws)), {
+    message: 'Specify pglite OR url/connection_string/aws, not both',
+    path: ['pglite'],
   })
 
 export type Config = z.infer<typeof configSchema>

--- a/packages/destination-postgres/src/spec.ts
+++ b/packages/destination-postgres/src/spec.ts
@@ -19,6 +19,10 @@ export const configSchema = z
       })
       .optional()
       .describe('AWS RDS IAM authentication config'),
+    allow_experimental_pglite: z
+      .boolean()
+      .optional()
+      .describe('Enable experimental PGlite support (required to use pglite config or file:///memory:// URLs)'),
     pglite: z
       .union([
         z.literal(true),
@@ -43,6 +47,19 @@ export const configSchema = z
     message: 'Specify pglite OR url/connection_string/aws, not both',
     path: ['pglite'],
   })
+  .refine(
+    (config) => {
+      if (config.pglite) return config.allow_experimental_pglite === true
+      const url = config.url ?? config.connection_string
+      if (url && (url.startsWith('file://') || url.startsWith('memory://')))
+        return config.allow_experimental_pglite === true
+      return true
+    },
+    {
+      message: 'Set allow_experimental_pglite: true to use PGlite or file:///memory:// URLs',
+      path: ['allow_experimental_pglite'],
+    }
+  )
 
 export type Config = z.infer<typeof configSchema>
 

--- a/packages/util-postgres/package.json
+++ b/packages/util-postgres/package.json
@@ -8,6 +8,16 @@
       "bun": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./sql": {
+      "bun": "./src/sql.ts",
+      "types": "./dist/sql.d.ts",
+      "import": "./dist/sql.js"
+    },
+    "./upsert": {
+      "bun": "./src/upsert.ts",
+      "types": "./dist/upsert.d.ts",
+      "import": "./dist/upsert.js"
     }
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -506,6 +506,55 @@ importers:
         specifier: ^3.2.1
         version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1)
 
+  examples/browser-sync:
+    dependencies:
+      '@electric-sql/pglite':
+        specifier: ^0.4.5
+        version: 0.4.5
+      '@stripe/sync-destination-postgres':
+        specifier: workspace:*
+        version: link:../../packages/destination-postgres
+      '@stripe/sync-engine':
+        specifier: workspace:*
+        version: link:../../apps/engine
+      '@stripe/sync-protocol':
+        specifier: workspace:*
+        version: link:../../packages/protocol
+      '@stripe/sync-source-stripe':
+        specifier: workspace:*
+        version: link:../../packages/source-stripe
+      react:
+        specifier: 19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: 19.2.5
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@types/react':
+        specifier: 19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4
+        version: 4.7.0(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1))
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+      vite:
+        specifier: ^6
+        version: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1)
+
+  examples/pixel-app:
+    dependencies:
+      express:
+        specifier: ^4.21.0
+        version: 4.22.1
+      ioredis:
+        specifier: ^5.6.1
+        version: 5.10.1
+
   packages/destination-google-sheets:
     dependencies:
       '@stripe/sync-logger':
@@ -2913,6 +2962,10 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
   acorn-import-phases@1.0.4:
     resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
     engines: {node: '>=10.13.0'}
@@ -2991,6 +3044,9 @@ packages:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
 
+  array-flatten@1.1.1:
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
   arraybuffer.slice@0.0.7:
     resolution: {integrity: sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==}
 
@@ -3043,6 +3099,10 @@ packages:
   blob@0.0.5:
     resolution: {integrity: sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==}
 
+  body-parser@1.20.5:
+    resolution: {integrity: sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
@@ -3069,6 +3129,10 @@ packages:
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -3194,6 +3258,10 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
@@ -3204,6 +3272,13 @@ packages:
   convert-to-spaces@2.0.1:
     resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  cookie-signature@1.0.7:
+    resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
@@ -3218,6 +3293,14 @@ packages:
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
+
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   debug@3.1.0:
     resolution: {integrity: sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==}
@@ -3260,6 +3343,14 @@ packages:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  destroy@1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -3281,6 +3372,9 @@ packages:
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   electron-to-chromium@1.5.323:
     resolution: {integrity: sha512-oQm+FxbazvN2WICCbvJgj3IYPKV8awip57+W5VP+Aatk4kFU4pDYCPHZOX22Z27zpw8uttBehEqgK+VTJAYrVw==}
 
@@ -3289,6 +3383,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   engine.io-client@3.5.6:
     resolution: {integrity: sha512-2fDMKiXSU7bGRDCWEw9cHEdRNfoU8cpP6lt+nwJhv72tSJpO7YBsqMqYZ63eVvwX3l9prPl2k/mxhfVhY+SDWg==}
@@ -3337,6 +3435,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
@@ -3419,6 +3520,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
@@ -3430,6 +3535,10 @@ packages:
   expect-type@1.2.2:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
+
+  express@4.22.1:
+    resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
+    engines: {node: '>= 0.10.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -3488,6 +3597,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@1.3.2:
+    resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
+    engines: {node: '>= 0.8'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -3520,8 +3633,16 @@ packages:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
+
+  fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
 
   fs-monkey@1.1.0:
     resolution: {integrity: sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw==}
@@ -3668,6 +3789,10 @@ packages:
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -3675,6 +3800,10 @@ packages:
   hyperdyperid@1.2.0:
     resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
     engines: {node: '>=10.18'}
+
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -3713,6 +3842,9 @@ packages:
   indexof@0.0.1:
     resolution: {integrity: sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg==}
 
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   ink@7.0.1:
     resolution: {integrity: sha512-o6LAC268PLawlGVYrXTyaTfke4VtJftEheuwbgkQf7yvSXyWp1nRwBbAyKEkWXFZZsW/la5wrMuNbuBvZK2C1w==}
     engines: {node: '>=22'}
@@ -3729,6 +3861,10 @@ packages:
   ioredis@5.10.1:
     resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
     engines: {node: '>=12.22.0'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -3965,10 +4101,17 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+
   memfs@4.57.1:
     resolution: {integrity: sha512-WvzrWPwMQT+PtbX2Et64R4qXKK0fj/8pO85MrUCzymX3twwCiJCdvntW3HdhG1teLJcHDDLIKx5+c3HckWYZtQ==}
     peerDependencies:
       tslib: '2'
+
+  merge-descriptors@1.0.3:
+    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -3976,6 +4119,10 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -3988,6 +4135,11 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -4032,6 +4184,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
@@ -4090,6 +4246,10 @@ packages:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
 
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
@@ -4141,6 +4301,10 @@ packages:
   parseuri@0.0.6:
     resolution: {integrity: sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   patch-console@2.0.0:
     resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -4160,6 +4324,9 @@ packages:
   path-scurry@2.0.0:
     resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
     engines: {node: 20 || >=22}
+
+  path-to-regexp@0.1.13:
+    resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -4305,6 +4472,10 @@ packages:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
     engines: {node: '>=12.0.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -4316,11 +4487,23 @@ packages:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
     engines: {node: '>=0.6'}
 
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@2.5.3:
+    resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
+    engines: {node: '>= 0.8'}
 
   react-dom@19.2.5:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
@@ -4452,6 +4635,17 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@0.19.2:
+    resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
+    engines: {node: '>= 0.8.0'}
+
+  serve-static@1.16.3:
+    resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
+    engines: {node: '>= 0.8.0'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -4544,6 +4738,10 @@ packages:
 
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
@@ -4725,6 +4923,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
@@ -4764,6 +4966,10 @@ packages:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
     engines: {node: '>=20'}
 
+  type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -4784,6 +4990,10 @@ packages:
 
   unionfs@4.6.0:
     resolution: {integrity: sha512-fJAy3gTHjFi5S3TP5EGdjs/OUMFFvI/ady3T8qVuZfkv8Qi8prV/Q8BuFEgODJslhZTT2z2qdD2lGdee9qjEnA==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -4820,6 +5030,10 @@ packages:
       '@types/react':
         optional: true
 
+  utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
+
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
@@ -4827,6 +5041,10 @@ packages:
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -7428,14 +7646,6 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.2.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.2.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1)
-
   '@vitest/mocker@3.2.4(vite@7.2.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -7568,6 +7778,11 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
   acorn-import-phases@1.0.4(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -7629,6 +7844,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  array-flatten@1.1.1: {}
+
   arraybuffer.slice@0.0.7: {}
 
   assertion-error@2.0.1: {}
@@ -7670,6 +7887,23 @@ snapshots:
 
   blob@0.0.5: {}
 
+  body-parser@1.20.5:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 2.5.3
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   bowser@2.14.1: {}
 
   brace-expansion@1.1.12:
@@ -7701,6 +7935,8 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  bytes@3.1.2: {}
 
   cac@6.7.14: {}
 
@@ -7819,11 +8055,19 @@ snapshots:
 
   consola@3.4.2: {}
 
+  content-disposition@0.5.4:
+    dependencies:
+      safe-buffer: 5.2.1
+
   content-type@1.0.5: {}
 
   convert-source-map@2.0.0: {}
 
   convert-to-spaces@2.0.1: {}
+
+  cookie-signature@1.0.7: {}
+
+  cookie@0.7.2: {}
 
   crelt@1.0.6: {}
 
@@ -7836,6 +8080,10 @@ snapshots:
   csstype@3.2.3: {}
 
   data-uri-to-buffer@4.0.1: {}
+
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
 
   debug@3.1.0:
     dependencies:
@@ -7859,6 +8107,10 @@ snapshots:
 
   denque@2.1.0: {}
 
+  depd@2.0.0: {}
+
+  destroy@1.2.0: {}
+
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
@@ -7877,11 +8129,15 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  ee-first@1.1.1: {}
+
   electron-to-chromium@1.5.323: {}
 
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  encodeurl@2.0.0: {}
 
   engine.io-client@3.5.6:
     dependencies:
@@ -7967,6 +8223,8 @@ snapshots:
       '@esbuild/win32-x64': 0.28.0
 
   escalade@3.2.0: {}
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@2.0.0: {}
 
@@ -8065,11 +8323,49 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
   event-target-shim@5.0.1: {}
 
   events@3.3.0: {}
 
   expect-type@1.2.2: {}
+
+  express@4.22.1:
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.5
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.0.7
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.3.2
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      merge-descriptors: 1.0.3
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.13
+      proxy-addr: 2.0.7
+      qs: 6.14.0
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.19.2
+      serve-static: 1.16.3
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extend@3.0.2: {}
 
@@ -8124,6 +8420,18 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@1.3.2:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -8155,7 +8463,11 @@ snapshots:
     dependencies:
       fetch-blob: 3.2.0
 
+  forwarded@0.2.0: {}
+
   fraction.js@5.3.4: {}
+
+  fresh@0.5.2: {}
 
   fs-monkey@1.1.0: {}
 
@@ -8322,6 +8634,14 @@ snapshots:
 
   hookable@5.5.3: {}
 
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
   https-proxy-agent@7.0.6(supports-color@10.2.2):
     dependencies:
       agent-base: 7.1.4
@@ -8330,6 +8650,10 @@ snapshots:
       - supports-color
 
   hyperdyperid@1.2.0: {}
+
+  iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
 
   iconv-lite@0.6.3:
     dependencies:
@@ -8357,6 +8681,8 @@ snapshots:
   index-to-position@1.2.0: {}
 
   indexof@0.0.1: {}
+
+  inherits@2.0.4: {}
 
   ink@7.0.1(@types/react@19.2.14)(react@19.2.5):
     dependencies:
@@ -8405,6 +8731,8 @@ snapshots:
       standard-as-callback: 2.1.0
     transitivePeerDependencies:
       - supports-color
+
+  ipaddr.js@1.9.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -8586,6 +8914,8 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  media-typer@0.3.0: {}
+
   memfs@4.57.1(tslib@2.8.1):
     dependencies:
       '@jsonjoy.com/fs-core': 4.57.1(tslib@2.8.1)
@@ -8603,9 +8933,13 @@ snapshots:
       tree-dump: 1.1.0(tslib@2.8.1)
       tslib: 2.8.1
 
+  merge-descriptors@1.0.3: {}
+
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  methods@1.1.2: {}
 
   micromatch@4.0.8:
     dependencies:
@@ -8617,6 +8951,8 @@ snapshots:
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime@1.6.0: {}
 
   mimic-fn@2.1.0: {}
 
@@ -8649,6 +8985,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
+
+  negotiator@0.6.3: {}
 
   neo-async@2.6.2: {}
 
@@ -8695,6 +9033,10 @@ snapshots:
   object-inspect@1.13.4: {}
 
   on-exit-leak-free@2.1.2: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   onetime@5.1.2:
     dependencies:
@@ -8755,6 +9097,8 @@ snapshots:
 
   parseuri@0.0.6: {}
 
+  parseurl@1.3.3: {}
+
   patch-console@2.0.0: {}
 
   path-exists@4.0.0: {}
@@ -8767,6 +9111,8 @@ snapshots:
     dependencies:
       lru-cache: 11.2.2
       minipass: 7.1.2
+
+  path-to-regexp@0.1.13: {}
 
   pathe@2.0.3: {}
 
@@ -8921,6 +9267,11 @@ snapshots:
       '@types/node': 24.10.1
       long: 5.3.2
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
@@ -8929,9 +9280,22 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+
   queue-microtask@1.2.3: {}
 
   quick-format-unescaped@4.0.4: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@2.5.3:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
 
   react-dom@19.2.5(react@19.2.5):
     dependencies:
@@ -9064,6 +9428,35 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.3: {}
+
+  send@0.19.2:
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@1.16.3:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.19.2
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.34.5:
     dependencies:
@@ -9204,6 +9597,8 @@ snapshots:
   stackback@0.0.2: {}
 
   standard-as-callback@2.1.0: {}
+
+  statuses@2.0.2: {}
 
   std-env@3.9.0: {}
 
@@ -9353,6 +9748,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   tr46@0.0.3: {}
 
   tree-dump@1.1.0(tslib@2.8.1):
@@ -9384,6 +9781,11 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
+  type-is@1.6.18:
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
+
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
@@ -9397,6 +9799,8 @@ snapshots:
   unionfs@4.6.0:
     dependencies:
       fs-monkey: 1.1.0
+
+  unpipe@1.0.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
@@ -9427,9 +9831,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  utils-merge@1.0.1: {}
+
   uuid@11.1.0: {}
 
   uuid@9.0.1: {}
+
+  vary@1.1.2: {}
 
   vite-node@3.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1):
     dependencies:
@@ -9528,7 +9936,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.2.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(vite@7.2.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -529,8 +529,8 @@ importers:
         specifier: ^3.1013.0
         version: 3.1013.0
       '@electric-sql/pglite':
-        specifier: ^0.2.17
-        version: 0.2.17
+        specifier: ^0.4.5
+        version: 0.4.5
       '@types/pg':
         specifier: ^8.15.5
         version: 8.15.6
@@ -1004,6 +1004,9 @@ packages:
 
   '@electric-sql/pglite@0.2.17':
     resolution: {integrity: sha512-qEpKRT2oUaWDH6tjRxLHjdzMqRUGYDnGZlKrnL4dJ77JVMcP2Hpo3NYnOSPKdZdeec57B6QPprCUFg0picx5Pw==}
+
+  '@electric-sql/pglite@0.4.5':
+    resolution: {integrity: sha512-aGG2zGEyZzGWKy8P+9ZoNUV0jxt1+hgbeTf+bVAYyxVZZLXg3/9aFlfLxb08AYZVAfAkQlQIysmWjhc5hwDG8g==}
 
   '@emnapi/runtime@1.9.1':
     resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
@@ -5558,6 +5561,8 @@ snapshots:
       w3c-keyname: 2.2.8
 
   '@electric-sql/pglite@0.2.17': {}
+
+  '@electric-sql/pglite@0.4.5': {}
 
   '@emnapi/runtime@1.9.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -539,12 +539,27 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4
         version: 4.7.0(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1))
+      buffer:
+        specifier: ^6.0.3
+        version: 6.0.3
+      os-browserify:
+        specifier: ^0.3.0
+        version: 0.3.0
+      path-browserify:
+        specifier: ^1.0.1
+        version: 1.0.1
+      stream-browserify:
+        specifier: ^3.0.0
+        version: 3.0.0
       typescript:
         specifier: ^5
         version: 5.9.3
       vite:
         specifier: ^6
         version: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1)
+      vite-plugin-node-polyfills:
+        specifier: ^0.26.0
+        version: 0.26.0(rollup@4.53.1)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1))
 
   examples/pixel-app:
     dependencies:
@@ -2227,6 +2242,24 @@ packages:
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
+  '@rollup/plugin-inject@5.0.5':
+    resolution: {integrity: sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/pluginutils@5.3.0':
+    resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rollup/rollup-android-arm-eabi@4.53.1':
     resolution: {integrity: sha512-bxZtughE4VNVJlL1RdoSE545kc4JxL7op57KKoi59/gwuU5rV6jLWFXXc8jwgFoT6vtj+ZjO+Z2C5nrY0Cl6wA==}
     cpu: [arm]
@@ -3050,6 +3083,12 @@ packages:
   arraybuffer.slice@0.0.7:
     resolution: {integrity: sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==}
 
+  asn1.js@4.10.1:
+    resolution: {integrity: sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==}
+
+  assert@2.1.0:
+    resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -3071,6 +3110,10 @@ packages:
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
+
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
 
   axios@1.13.5:
     resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
@@ -3099,6 +3142,12 @@ packages:
   blob@0.0.5:
     resolution: {integrity: sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==}
 
+  bn.js@4.12.3:
+    resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
+
+  bn.js@5.2.3:
+    resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
+
   body-parser@1.20.5:
     resolution: {integrity: sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -3116,6 +3165,32 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  brorand@1.1.0:
+    resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
+
+  browser-resolve@2.0.0:
+    resolution: {integrity: sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==}
+
+  browserify-aes@1.2.0:
+    resolution: {integrity: sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==}
+
+  browserify-cipher@1.0.1:
+    resolution: {integrity: sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==}
+
+  browserify-des@1.0.2:
+    resolution: {integrity: sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==}
+
+  browserify-rsa@4.1.1:
+    resolution: {integrity: sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==}
+    engines: {node: '>= 0.10'}
+
+  browserify-sign@4.2.5:
+    resolution: {integrity: sha512-C2AUdAJg6rlM2W5QMp2Q4KGQMVBwR1lIimTsUnutJ8bMpW5B52pGpR2gEnNBNwijumDo5FojQ0L9JrXA8m4YEw==}
+    engines: {node: '>= 0.10'}
+
+  browserify-zlib@0.2.0:
+    resolution: {integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==}
+
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -3127,8 +3202,17 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  buffer-xor@1.0.3:
+    resolution: {integrity: sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  builtin-status-codes@3.0.0:
+    resolution: {integrity: sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -3140,6 +3224,10 @@ packages:
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
     engines: {node: '>= 0.4'}
 
   call-bound@1.0.4:
@@ -3175,6 +3263,10 @@ packages:
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
+
+  cipher-base@1.0.7:
+    resolution: {integrity: sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==}
+    engines: {node: '>= 0.10'}
 
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
@@ -3258,6 +3350,12 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  console-browserify@1.2.0:
+    resolution: {integrity: sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==}
+
+  constants-browserify@1.0.0:
+    resolution: {integrity: sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==}
+
   content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
@@ -3280,12 +3378,31 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  create-ecdh@4.0.4:
+    resolution: {integrity: sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==}
+
+  create-hash@1.2.0:
+    resolution: {integrity: sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==}
+
+  create-hmac@1.1.7:
+    resolution: {integrity: sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==}
+
+  create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  crypto-browserify@3.12.1:
+    resolution: {integrity: sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==}
+    engines: {node: '>= 0.10'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -3335,6 +3452,14 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
@@ -3347,6 +3472,9 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  des.js@1.1.0:
+    resolution: {integrity: sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==}
+
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -3357,6 +3485,13 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  diffie-hellman@5.0.3:
+    resolution: {integrity: sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==}
+
+  domain-browser@4.22.0:
+    resolution: {integrity: sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==}
+    engines: {node: '>=10'}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -3377,6 +3512,9 @@ packages:
 
   electron-to-chromium@1.5.323:
     resolution: {integrity: sha512-oQm+FxbazvN2WICCbvJgj3IYPKV8awip57+W5VP+Aatk4kFU4pDYCPHZOX22Z27zpw8uttBehEqgK+VTJAYrVw==}
+
+  elliptic@6.6.1:
+    resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -3513,6 +3651,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -3531,6 +3672,9 @@ packages:
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+
+  evp_bytestokey@1.0.3:
+    resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
 
   expect-type@1.2.2:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
@@ -3621,6 +3765,10 @@ packages:
       debug:
         optional: true
 
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
+
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
@@ -3667,6 +3815,10 @@ packages:
   gcp-metadata@6.1.1:
     resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
     engines: {node: '>=14'}
+
+  generator-function@2.0.1:
+    resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
+    engines: {node: '>= 0.4'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -3766,6 +3918,9 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -3774,13 +3929,31 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
+  hash-base@3.0.5:
+    resolution: {integrity: sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==}
+    engines: {node: '>= 0.10'}
+
+  hash-base@3.1.2:
+    resolution: {integrity: sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==}
+    engines: {node: '>= 0.8'}
+
+  hash.js@1.1.7:
+    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
+
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
   heap-js@2.7.1:
     resolution: {integrity: sha512-EQfezRg0NCZGNlhlDR3Evrw1FVL2G3LhU7EgPoxufQKruNBSYA8MiRPHeWbU+36o+Fhel0wMwM+sLEiBAlNLJA==}
     engines: {node: '>=10.0.0'}
+
+  hmac-drbg@1.0.1:
+    resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
 
   hono@4.12.8:
     resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
@@ -3792,6 +3965,9 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  https-browserify@1.0.0:
+    resolution: {integrity: sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -3866,6 +4042,18 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  is-arguments@1.2.0:
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
+    engines: {node: '>= 0.4'}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
+
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -3878,6 +4066,10 @@ packages:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
     engines: {node: '>=18'}
 
+  is-generator-function@1.1.2:
+    resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
+    engines: {node: '>= 0.4'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
@@ -3887,19 +4079,41 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
+  is-nan@1.3.2:
+    resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
+    engines: {node: '>= 0.4'}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
 
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isarray@2.0.1:
     resolution: {integrity: sha512-c2cu3UxbI+b6kR3fy0nRnAhodsvR9dx7U5+znCOzdj6IfP3upFURTr0Xl5BlQZNKZjEtxrmVyfSdeE3O57smoQ==}
 
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isomorphic-timers-promises@1.0.1:
+    resolution: {integrity: sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==}
+    engines: {node: '>=10'}
 
   ix@7.0.0:
     resolution: {integrity: sha512-hgVnphYh+ytIEsmjeym5wP2GPaM3+RZf7zCrZXE7gjwwmpIBEg0t6GRX7BbdXzTosXCstEAzdPxpyplGBYnIbw==}
@@ -4101,6 +4315,9 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  md5.js@1.3.5:
+    resolution: {integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==}
+
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
@@ -4128,6 +4345,10 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  miller-rabin@4.0.1:
+    resolution: {integrity: sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==}
+    hasBin: true
+
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
@@ -4144,6 +4365,12 @@ packages:
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+
+  minimalistic-crypto-utils@1.0.1:
+    resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
 
   minimatch@10.1.1:
     resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
@@ -4238,8 +4465,24 @@ packages:
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
+  node-stdlib-browser@1.3.1:
+    resolution: {integrity: sha512-X75ZN8DCLftGM5iKwoYLA3rjnrAEs97MkzvSd4q2746Tgpg8b8XWiBGiBG4ZpgcAqBgtgPHTiAc8ZMCvZuikDw==}
+    engines: {node: '>=10'}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  object-is@1.1.6:
+    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
+    engines: {node: '>= 0.4'}
+
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
+  object.assign@4.1.7:
+    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
     engines: {node: '>= 0.4'}
 
   on-exit-leak-free@2.1.2:
@@ -4276,6 +4519,9 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  os-browserify@0.3.0:
+    resolution: {integrity: sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -4287,9 +4533,16 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-asn1@5.1.9:
+    resolution: {integrity: sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==}
+    engines: {node: '>= 0.10'}
 
   parse-json@8.3.0:
     resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
@@ -4309,6 +4562,9 @@ packages:
     resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -4320,6 +4576,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
   path-scurry@2.0.0:
     resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
@@ -4334,6 +4593,10 @@ packages:
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
+
+  pbkdf2@3.1.5:
+    resolution: {integrity: sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==}
+    engines: {node: '>= 0.10'}
 
   pg-cloudflare@1.2.7:
     resolution: {integrity: sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==}
@@ -4400,6 +4663,10 @@ packages:
     resolution: {integrity: sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==}
     hasBin: true
 
+  pkg-dir@5.0.0:
+    resolution: {integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==}
+    engines: {node: '>=10'}
+
   playwright-core@1.59.1:
     resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
     engines: {node: '>=18'}
@@ -4413,6 +4680,10 @@ packages:
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
+
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -4454,6 +4725,9 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   process-warning@3.0.0:
     resolution: {integrity: sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==}
 
@@ -4479,6 +4753,12 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  public-encrypt@4.0.3:
+    resolution: {integrity: sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==}
+
+  punycode@1.4.1:
+    resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -4491,11 +4771,21 @@ packages:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
 
+  querystring-es3@0.2.1:
+    resolution: {integrity: sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==}
+    engines: {node: '>=0.4.x'}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  randombytes@2.1.0:
+    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+
+  randomfill@1.0.4:
+    resolution: {integrity: sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==}
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
@@ -4554,6 +4844,13 @@ packages:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   readable-stream@4.7.0:
     resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -4585,6 +4882,11 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
   restore-cursor@4.0.0:
     resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -4598,6 +4900,10 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
+  ripemd160@2.0.3:
+    resolution: {integrity: sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==}
+    engines: {node: '>= 0.8'}
+
   rollup@4.53.1:
     resolution: {integrity: sha512-n2I0V0lN3E9cxxMqBCT3opWOiQBzRN7UG60z/WDKqdX2zHUS/39lezBcsckZFsV6fUTSnfqI7kHf60jDAPGKug==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -4609,8 +4915,15 @@ packages:
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
 
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
@@ -4643,8 +4956,20 @@ packages:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
 
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  sha.js@2.4.12:
+    resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
+    engines: {node: '>= 0.10'}
+    hasBin: true
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -4746,6 +5071,12 @@ packages:
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
+  stream-browserify@3.0.0:
+    resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
+
+  stream-http@3.2.0:
+    resolution: {integrity: sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -4757,6 +5088,9 @@ packages:
   string-width@8.2.0:
     resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
     engines: {node: '>=20'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -4833,6 +5167,10 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
   swc-loader@0.2.7:
     resolution: {integrity: sha512-nwYWw3Fh9ame3Rtm7StS9SBLpHRRnYcK7bnpF3UKZmesAK0gw2/ADvlURFAINmPvKtDLzp+GBiP9yLoEjg6S9w==}
     peerDependencies:
@@ -4894,6 +5232,10 @@ packages:
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
+  timers-browserify@2.0.12:
+    resolution: {integrity: sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==}
+    engines: {node: '>=0.6.0'}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -4918,6 +5260,10 @@ packages:
 
   to-array@0.1.4:
     resolution: {integrity: sha512-LhVdShQD/4Mk4zXNroIQZJC+Ap3zgLcDuwEdcmLv9CCO73NWockQDwyUnW/m8VX/EElfL6FcYx7EeutN4HJA6A==}
+
+  to-buffer@1.2.2:
+    resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
+    engines: {node: '>= 0.4'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -4954,6 +5300,9 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tty-browserify@0.0.1:
+    resolution: {integrity: sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -4969,6 +5318,10 @@ packages:
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
+
+  typed-array-buffer@1.0.3:
+    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
+    engines: {node: '>= 0.4'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -5010,6 +5363,10 @@ packages:
   url-template@2.0.8:
     resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
 
+  url@0.11.4:
+    resolution: {integrity: sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==}
+    engines: {node: '>= 0.4'}
+
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
     engines: {node: '>=10'}
@@ -5029,6 +5386,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  util@0.12.5:
+    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
 
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
@@ -5050,6 +5413,11 @@ packages:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
+
+  vite-plugin-node-polyfills@0.26.0:
+    resolution: {integrity: sha512-BAe5YzJf368XGev02hDvioidx4uVH8dqEJlG73bjQSxM26/AQnGcKFomq9n3vGq5yqpSHKN4h1XQNxx9l98mBg==}
+    peerDependencies:
+      vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   vite@6.4.1:
     resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
@@ -5159,6 +5527,9 @@ packages:
       jsdom:
         optional: true
 
+  vm-browserify@1.1.2:
+    resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}
+
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
@@ -5189,6 +5560,10 @@ packages:
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  which-typed-array@1.1.20:
+    resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
+    engines: {node: '>= 0.4'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -6856,6 +7231,22 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
+  '@rollup/plugin-inject@5.0.5(rollup@4.53.1)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.53.1)
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+    optionalDependencies:
+      rollup: 4.53.1
+
+  '@rollup/pluginutils@5.3.0(rollup@4.53.1)':
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-walker: 2.0.2
+      picomatch: 4.0.3
+    optionalDependencies:
+      rollup: 4.53.1
+
   '@rollup/rollup-android-arm-eabi@4.53.1':
     optional: true
 
@@ -7646,6 +8037,14 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
+  '@vitest/mocker@3.2.4(vite@7.2.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.2.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1)
+
   '@vitest/mocker@3.2.4(vite@7.2.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -7848,6 +8247,20 @@ snapshots:
 
   arraybuffer.slice@0.0.7: {}
 
+  asn1.js@4.10.1:
+    dependencies:
+      bn.js: 4.12.3
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+
+  assert@2.1.0:
+    dependencies:
+      call-bind: 1.0.9
+      is-nan: 1.3.2
+      object-is: 1.1.6
+      object.assign: 4.1.7
+      util: 0.12.5
+
   assertion-error@2.0.1: {}
 
   asynckit@0.4.0: {}
@@ -7864,6 +8277,10 @@ snapshots:
       picocolors: 1.1.1
       postcss: 8.5.8
       postcss-value-parser: 4.2.0
+
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
 
   axios@1.13.5:
     dependencies:
@@ -7886,6 +8303,10 @@ snapshots:
   bignumber.js@9.3.1: {}
 
   blob@0.0.5: {}
+
+  bn.js@4.12.3: {}
+
+  bn.js@5.2.3: {}
 
   body-parser@1.20.5:
     dependencies:
@@ -7919,6 +8340,56 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  brorand@1.1.0: {}
+
+  browser-resolve@2.0.0:
+    dependencies:
+      resolve: 1.22.12
+
+  browserify-aes@1.2.0:
+    dependencies:
+      buffer-xor: 1.0.3
+      cipher-base: 1.0.7
+      create-hash: 1.2.0
+      evp_bytestokey: 1.0.3
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+
+  browserify-cipher@1.0.1:
+    dependencies:
+      browserify-aes: 1.2.0
+      browserify-des: 1.0.2
+      evp_bytestokey: 1.0.3
+
+  browserify-des@1.0.2:
+    dependencies:
+      cipher-base: 1.0.7
+      des.js: 1.1.0
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+
+  browserify-rsa@4.1.1:
+    dependencies:
+      bn.js: 5.2.3
+      randombytes: 2.1.0
+      safe-buffer: 5.2.1
+
+  browserify-sign@4.2.5:
+    dependencies:
+      bn.js: 5.2.3
+      browserify-rsa: 4.1.1
+      create-hash: 1.2.0
+      create-hmac: 1.1.7
+      elliptic: 6.6.1
+      inherits: 2.0.4
+      parse-asn1: 5.1.9
+      readable-stream: 2.3.8
+      safe-buffer: 5.2.1
+
+  browserify-zlib@0.2.0:
+    dependencies:
+      pako: 1.0.11
+
   browserslist@4.28.1:
     dependencies:
       baseline-browser-mapping: 2.10.10
@@ -7931,10 +8402,19 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  buffer-xor@1.0.3: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  builtin-status-codes@3.0.0: {}
 
   bytes@3.1.2: {}
 
@@ -7944,6 +8424,13 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  call-bind@1.0.9:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
 
   call-bound@1.0.4:
     dependencies:
@@ -7974,6 +8461,12 @@ snapshots:
   check-error@2.1.1: {}
 
   chrome-trace-event@1.0.4: {}
+
+  cipher-base@1.0.7:
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+      to-buffer: 1.2.2
 
   citty@0.1.6:
     dependencies:
@@ -8055,6 +8548,10 @@ snapshots:
 
   consola@3.4.2: {}
 
+  console-browserify@1.2.0: {}
+
+  constants-browserify@1.0.0: {}
+
   content-disposition@0.5.4:
     dependencies:
       safe-buffer: 5.2.1
@@ -8069,6 +8566,32 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  core-util-is@1.0.3: {}
+
+  create-ecdh@4.0.4:
+    dependencies:
+      bn.js: 4.12.3
+      elliptic: 6.6.1
+
+  create-hash@1.2.0:
+    dependencies:
+      cipher-base: 1.0.7
+      inherits: 2.0.4
+      md5.js: 1.3.5
+      ripemd160: 2.0.3
+      sha.js: 2.4.12
+
+  create-hmac@1.1.7:
+    dependencies:
+      cipher-base: 1.0.7
+      create-hash: 1.2.0
+      inherits: 2.0.4
+      ripemd160: 2.0.3
+      safe-buffer: 5.2.1
+      sha.js: 2.4.12
+
+  create-require@1.1.1: {}
+
   crelt@1.0.6: {}
 
   cross-spawn@7.0.6:
@@ -8076,6 +8599,21 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  crypto-browserify@3.12.1:
+    dependencies:
+      browserify-cipher: 1.0.1
+      browserify-sign: 4.2.5
+      create-ecdh: 4.0.4
+      create-hash: 1.2.0
+      create-hmac: 1.1.7
+      diffie-hellman: 5.0.3
+      hash-base: 3.0.5
+      inherits: 2.0.4
+      pbkdf2: 3.1.5
+      public-encrypt: 4.0.3
+      randombytes: 2.1.0
+      randomfill: 1.0.4
 
   csstype@3.2.3: {}
 
@@ -8103,17 +8641,42 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
+
   delayed-stream@1.0.0: {}
 
   denque@2.1.0: {}
 
   depd@2.0.0: {}
 
+  des.js@1.1.0:
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+
   destroy@1.2.0: {}
 
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
+
+  diffie-hellman@5.0.3:
+    dependencies:
+      bn.js: 4.12.3
+      miller-rabin: 4.0.1
+      randombytes: 2.1.0
+
+  domain-browser@4.22.0: {}
 
   dotenv@16.6.1: {}
 
@@ -8132,6 +8695,16 @@ snapshots:
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.323: {}
+
+  elliptic@6.6.1:
+    dependencies:
+      bn.js: 4.12.3
+      brorand: 1.1.0
+      hash.js: 1.1.7
+      hmac-drbg: 1.0.1
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
 
   emoji-regex@8.0.0: {}
 
@@ -8317,6 +8890,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@2.0.2: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -8328,6 +8903,11 @@ snapshots:
   event-target-shim@5.0.1: {}
 
   events@3.3.0: {}
+
+  evp_bytestokey@1.0.3:
+    dependencies:
+      md5.js: 1.3.5
+      safe-buffer: 5.2.1
 
   expect-type@1.2.2: {}
 
@@ -8446,6 +9026,10 @@ snapshots:
 
   follow-redirects@1.15.11: {}
 
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
+
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -8498,6 +9082,8 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  generator-function@2.0.1: {}
 
   gensync@1.0.0-beta.2: {}
 
@@ -8618,17 +9204,48 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
   has-symbols@1.1.0: {}
 
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.1.0
 
+  hash-base@3.0.5:
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+
+  hash-base@3.1.2:
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 2.3.8
+      safe-buffer: 5.2.1
+      to-buffer: 1.2.2
+
+  hash.js@1.1.7:
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
 
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
   heap-js@2.7.1: {}
+
+  hmac-drbg@1.0.1:
+    dependencies:
+      hash.js: 1.1.7
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
 
   hono@4.12.8: {}
 
@@ -8641,6 +9258,8 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  https-browserify@1.0.0: {}
 
   https-proxy-agent@7.0.6(supports-color@10.2.2):
     dependencies:
@@ -8734,6 +9353,17 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  is-arguments@1.2.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-callable@1.2.7: {}
+
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.3
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -8742,19 +9372,49 @@ snapshots:
     dependencies:
       get-east-asian-width: 1.5.0
 
+  is-generator-function@1.1.2:
+    dependencies:
+      call-bound: 1.0.4
+      generator-function: 2.0.1
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
 
   is-in-ci@2.0.0: {}
 
+  is-nan@1.3.2:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+
   is-number@7.0.0: {}
+
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   is-stream@2.0.1: {}
 
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.20
+
+  isarray@1.0.0: {}
+
   isarray@2.0.1: {}
 
+  isarray@2.0.5: {}
+
   isexe@2.0.0: {}
+
+  isomorphic-timers-promises@1.0.1: {}
 
   ix@7.0.0:
     dependencies:
@@ -8914,6 +9574,12 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  md5.js@1.3.5:
+    dependencies:
+      hash-base: 3.0.5
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+
   media-typer@0.3.0: {}
 
   memfs@4.57.1(tslib@2.8.1):
@@ -8946,6 +9612,11 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  miller-rabin@4.0.1:
+    dependencies:
+      bn.js: 4.12.3
+      brorand: 1.1.0
+
   mime-db@1.52.0: {}
 
   mime-types@2.1.35:
@@ -8955,6 +9626,10 @@ snapshots:
   mime@1.6.0: {}
 
   mimic-fn@2.1.0: {}
+
+  minimalistic-assert@1.0.1: {}
+
+  minimalistic-crypto-utils@1.0.1: {}
 
   minimatch@10.1.1:
     dependencies:
@@ -9030,7 +9705,53 @@ snapshots:
 
   node-releases@2.0.36: {}
 
+  node-stdlib-browser@1.3.1:
+    dependencies:
+      assert: 2.1.0
+      browser-resolve: 2.0.0
+      browserify-zlib: 0.2.0
+      buffer: 5.7.1
+      console-browserify: 1.2.0
+      constants-browserify: 1.0.0
+      create-require: 1.1.1
+      crypto-browserify: 3.12.1
+      domain-browser: 4.22.0
+      events: 3.3.0
+      https-browserify: 1.0.0
+      isomorphic-timers-promises: 1.0.1
+      os-browserify: 0.3.0
+      path-browserify: 1.0.1
+      pkg-dir: 5.0.0
+      process: 0.11.10
+      punycode: 1.4.1
+      querystring-es3: 0.2.1
+      readable-stream: 3.6.2
+      stream-browserify: 3.0.0
+      stream-http: 3.2.0
+      string_decoder: 1.3.0
+      timers-browserify: 2.0.12
+      tty-browserify: 0.0.1
+      url: 0.11.4
+      util: 0.12.5
+      vm-browserify: 1.1.2
+
   object-inspect@1.13.4: {}
+
+  object-is@1.1.6:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+
+  object-keys@1.1.1: {}
+
+  object.assign@4.1.7:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+      has-symbols: 1.1.0
+      object-keys: 1.1.1
 
   on-exit-leak-free@2.1.2: {}
 
@@ -9073,6 +9794,8 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  os-browserify@0.3.0: {}
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -9083,9 +9806,19 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  pako@1.0.11: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-asn1@5.1.9:
+    dependencies:
+      asn1.js: 4.10.1
+      browserify-aes: 1.2.0
+      evp_bytestokey: 1.0.3
+      pbkdf2: 3.1.5
+      safe-buffer: 5.2.1
 
   parse-json@8.3.0:
     dependencies:
@@ -9101,11 +9834,15 @@ snapshots:
 
   patch-console@2.0.0: {}
 
+  path-browserify@1.0.1: {}
+
   path-exists@4.0.0: {}
 
   path-expression-matcher@1.1.3: {}
 
   path-key@3.1.1: {}
+
+  path-parse@1.0.7: {}
 
   path-scurry@2.0.0:
     dependencies:
@@ -9117,6 +9854,15 @@ snapshots:
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
+
+  pbkdf2@3.1.5:
+    dependencies:
+      create-hash: 1.2.0
+      create-hmac: 1.1.7
+      ripemd160: 2.0.3
+      safe-buffer: 5.2.1
+      sha.js: 2.4.12
+      to-buffer: 1.2.2
 
   pg-cloudflare@1.2.7:
     optional: true
@@ -9200,6 +9946,10 @@ snapshots:
       sonic-boom: 3.8.1
       thread-stream: 2.7.0
 
+  pkg-dir@5.0.0:
+    dependencies:
+      find-up: 5.0.0
+
   playwright-core@1.59.1: {}
 
   playwright@1.59.1:
@@ -9209,6 +9959,8 @@ snapshots:
       fsevents: 2.3.2
 
   pluralize@8.0.0: {}
+
+  possible-typed-array-names@1.1.0: {}
 
   postcss-value-parser@4.2.0: {}
 
@@ -9242,6 +9994,8 @@ snapshots:
 
   prettier@3.6.2: {}
 
+  process-nextick-args@2.0.1: {}
+
   process-warning@3.0.0: {}
 
   process-warning@5.0.0: {}
@@ -9274,6 +10028,17 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  public-encrypt@4.0.3:
+    dependencies:
+      bn.js: 4.12.3
+      browserify-rsa: 4.1.1
+      create-hash: 1.2.0
+      parse-asn1: 5.1.9
+      randombytes: 2.1.0
+      safe-buffer: 5.2.1
+
+  punycode@1.4.1: {}
+
   punycode@2.3.1: {}
 
   qs@6.14.0:
@@ -9284,9 +10049,20 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  querystring-es3@0.2.1: {}
+
   queue-microtask@1.2.3: {}
 
   quick-format-unescaped@4.0.4: {}
+
+  randombytes@2.1.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  randomfill@1.0.4:
+    dependencies:
+      randombytes: 2.1.0
+      safe-buffer: 5.2.1
 
   range-parser@1.2.1: {}
 
@@ -9338,6 +10114,22 @@ snapshots:
 
   react@19.2.5: {}
 
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
   readable-stream@4.7.0:
     dependencies:
       abort-controller: 3.0.0
@@ -9362,6 +10154,13 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
   restore-cursor@4.0.0:
     dependencies:
       onetime: 5.1.2
@@ -9373,6 +10172,11 @@ snapshots:
     dependencies:
       glob: 11.0.3
       package-json-from-dist: 1.0.1
+
+  ripemd160@2.0.3:
+    dependencies:
+      hash-base: 3.1.2
+      inherits: 2.0.4
 
   rollup@4.53.1:
     dependencies:
@@ -9410,7 +10214,15 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  safe-buffer@5.1.2: {}
+
   safe-buffer@5.2.1: {}
+
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
 
   safe-stable-stringify@2.5.0: {}
 
@@ -9456,7 +10268,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+
+  setimmediate@1.0.5: {}
+
   setprototypeof@1.2.0: {}
+
+  sha.js@2.4.12:
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+      to-buffer: 1.2.2
 
   sharp@0.34.5:
     dependencies:
@@ -9602,6 +10431,18 @@ snapshots:
 
   std-env@3.9.0: {}
 
+  stream-browserify@3.0.0:
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  stream-http@3.2.0:
+    dependencies:
+      builtin-status-codes: 3.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      xtend: 4.0.2
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -9618,6 +10459,10 @@ snapshots:
     dependencies:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.1.2
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   string_decoder@1.3.0:
     dependencies:
@@ -9678,6 +10523,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-preserve-symlinks-flag@1.0.0: {}
+
   swc-loader@0.2.7(@swc/core@1.15.21)(webpack@5.105.4(@swc/core@1.15.21)):
     dependencies:
       '@swc/core': 1.15.21
@@ -9727,6 +10574,10 @@ snapshots:
     dependencies:
       real-require: 0.2.0
 
+  timers-browserify@2.0.12:
+    dependencies:
+      setimmediate: 1.0.5
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -9743,6 +10594,12 @@ snapshots:
   tinyspy@4.0.3: {}
 
   to-array@0.1.4: {}
+
+  to-buffer@1.2.2:
+    dependencies:
+      isarray: 2.0.5
+      safe-buffer: 5.2.1
+      typed-array-buffer: 1.0.3
 
   to-regex-range@5.0.1:
     dependencies:
@@ -9771,6 +10628,8 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  tty-browserify@0.0.1: {}
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -9785,6 +10644,12 @@ snapshots:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
+
+  typed-array-buffer@1.0.3:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-typed-array: 1.1.15
 
   typescript@5.9.3: {}
 
@@ -9816,6 +10681,11 @@ snapshots:
 
   url-template@2.0.8: {}
 
+  url@0.11.4:
+    dependencies:
+      punycode: 1.4.1
+      qs: 6.15.1
+
   use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.5):
     dependencies:
       react: 19.2.5
@@ -9830,6 +10700,16 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
+
+  util-deprecate@1.0.2: {}
+
+  util@0.12.5:
+    dependencies:
+      inherits: 2.0.4
+      is-arguments: 1.2.0
+      is-generator-function: 1.1.2
+      is-typed-array: 1.1.15
+      which-typed-array: 1.1.20
 
   utils-merge@1.0.1: {}
 
@@ -9880,6 +10760,14 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vite-plugin-node-polyfills@0.26.0(rollup@4.53.1)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1)):
+    dependencies:
+      '@rollup/plugin-inject': 5.0.5(rollup@4.53.1)
+      node-stdlib-browser: 1.3.1
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - rollup
 
   vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1):
     dependencies:
@@ -9936,7 +10824,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.2.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(vite@7.2.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -10014,6 +10902,8 @@ snapshots:
       - tsx
       - yaml
 
+  vm-browserify@1.1.2: {}
+
   w3c-keyname@2.2.8: {}
 
   watchpack@2.5.1:
@@ -10063,6 +10953,16 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+
+  which-typed-array@1.1.20:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
 
   which@2.0.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -528,6 +528,9 @@ importers:
       '@aws-sdk/rds-signer':
         specifier: ^3.1013.0
         version: 3.1013.0
+      '@electric-sql/pglite':
+        specifier: ^0.2.17
+        version: 0.2.17
       '@types/pg':
         specifier: ^8.15.5
         version: 8.15.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,9 +164,15 @@ importers:
       '@stripe/sync-destination-postgres':
         specifier: workspace:*
         version: link:../../packages/destination-postgres
+      '@stripe/sync-destination-redis':
+        specifier: workspace:*
+        version: link:../../packages/destination-redis
       '@stripe/sync-destination-sqlite':
         specifier: workspace:*
         version: link:../../packages/destination-sqlite
+      '@stripe/sync-destination-stripe':
+        specifier: workspace:*
+        version: link:../../packages/destination-stripe
       '@stripe/sync-hono-zod-openapi':
         specifier: workspace:*
         version: link:../../packages/hono-zod-openapi
@@ -176,6 +182,12 @@ importers:
       '@stripe/sync-protocol':
         specifier: workspace:*
         version: link:../../packages/protocol
+      '@stripe/sync-source-metronome':
+        specifier: workspace:*
+        version: link:../../packages/source-metronome
+      '@stripe/sync-source-postgres':
+        specifier: workspace:*
+        version: link:../../packages/source-postgres
       '@stripe/sync-source-stripe':
         specifier: workspace:*
         version: link:../../packages/source-stripe
@@ -255,6 +267,9 @@ importers:
       '@stripe/sync-destination-sqlite':
         specifier: workspace:*
         version: link:../../packages/destination-sqlite
+      '@stripe/sync-destination-stripe':
+        specifier: workspace:*
+        version: link:../../packages/destination-stripe
       '@stripe/sync-engine':
         specifier: workspace:*
         version: link:../engine
@@ -267,6 +282,9 @@ importers:
       '@stripe/sync-protocol':
         specifier: workspace:*
         version: link:../../packages/protocol
+      '@stripe/sync-source-postgres':
+        specifier: workspace:*
+        version: link:../../packages/source-postgres
       '@stripe/sync-source-stripe':
         specifier: workspace:*
         version: link:../../packages/source-stripe
@@ -378,8 +396,8 @@ importers:
         specifier: ^6.26.0
         version: 6.40.0
       '@electric-sql/pglite':
-        specifier: ^0.2.0
-        version: 0.2.17
+        specifier: ^0.4.5
+        version: 0.4.5
       '@stripe/sync-source-stripe':
         specifier: workspace:*
         version: link:../../packages/source-stripe
@@ -436,6 +454,9 @@ importers:
       '@stripe/sync-destination-postgres':
         specifier: workspace:*
         version: link:../packages/destination-postgres
+      '@stripe/sync-destination-stripe':
+        specifier: workspace:*
+        version: link:../packages/destination-stripe
       '@stripe/sync-engine':
         specifier: workspace:*
         version: link:../apps/engine
@@ -448,6 +469,9 @@ importers:
       '@stripe/sync-service':
         specifier: workspace:*
         version: link:../apps/service
+      '@stripe/sync-source-postgres':
+        specifier: workspace:*
+        version: link:../packages/source-postgres
       '@stripe/sync-source-stripe':
         specifier: workspace:*
         version: link:../packages/source-stripe
@@ -538,6 +562,28 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1)
 
+  packages/destination-redis:
+    dependencies:
+      '@stripe/sync-logger':
+        specifier: workspace:*
+        version: link:../logger
+      '@stripe/sync-protocol':
+        specifier: workspace:*
+        version: link:../protocol
+      ioredis:
+        specifier: ^5.6.1
+        version: 5.10.1
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: ^24.5.0
+        version: 24.10.1
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1)
+
   packages/destination-sqlite:
     dependencies:
       '@stripe/sync-logger':
@@ -549,6 +595,28 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
+
+  packages/destination-stripe:
+    dependencies:
+      '@stripe/sync-logger':
+        specifier: workspace:*
+        version: link:../logger
+      '@stripe/sync-openapi':
+        specifier: workspace:*
+        version: link:../openapi
+      '@stripe/sync-protocol':
+        specifier: workspace:*
+        version: link:../protocol
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: ^24.10.1
+        version: 24.10.1
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/hono-zod-openapi:
     dependencies:
@@ -628,6 +696,50 @@ importers:
       vitest:
         specifier: ^3.2.1
         version: 3.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1)
+
+  packages/source-metronome:
+    dependencies:
+      '@stripe/sync-logger':
+        specifier: workspace:*
+        version: link:../logger
+      '@stripe/sync-protocol':
+        specifier: workspace:*
+        version: link:../protocol
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: ^24.5.0
+        version: 24.10.1
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1)
+
+  packages/source-postgres:
+    dependencies:
+      '@stripe/sync-logger':
+        specifier: workspace:*
+        version: link:../logger
+      '@stripe/sync-protocol':
+        specifier: workspace:*
+        version: link:../protocol
+      '@stripe/sync-util-postgres':
+        specifier: workspace:*
+        version: link:../util-postgres
+      pg:
+        specifier: ^8.16.3
+        version: 8.16.3
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@types/pg':
+        specifier: ^8.15.5
+        version: 8.20.0
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/source-stripe:
     dependencies:
@@ -1001,9 +1113,6 @@ packages:
 
   '@codemirror/view@6.40.0':
     resolution: {integrity: sha512-WA0zdU7xfF10+5I3HhUUq3kqOx3KjqmtQ9lqZjfK7jtYk4G72YW9rezcSywpaUMCWOMlq+6E0pO1IWg1TNIhtg==}
-
-  '@electric-sql/pglite@0.2.17':
-    resolution: {integrity: sha512-qEpKRT2oUaWDH6tjRxLHjdzMqRUGYDnGZlKrnL4dJ77JVMcP2Hpo3NYnOSPKdZdeec57B6QPprCUFg0picx5Pw==}
 
   '@electric-sql/pglite@0.4.5':
     resolution: {integrity: sha512-aGG2zGEyZzGWKy8P+9ZoNUV0jxt1+hgbeTf+bVAYyxVZZLXg3/9aFlfLxb08AYZVAfAkQlQIysmWjhc5hwDG8g==}
@@ -1414,6 +1523,9 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
+
+  '@ioredis/commands@1.5.1':
+    resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
 
   '@isaacs/balanced-match@4.0.1':
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
@@ -3029,6 +3141,10 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   code-excerpt@4.0.0:
     resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -3139,6 +3255,10 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -3606,6 +3726,10 @@ packages:
       react-devtools-core:
         optional: true
 
+  ioredis@5.10.1:
+    resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
+    engines: {node: '>=12.22.0'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -3806,6 +3930,12 @@ packages:
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -4249,6 +4379,14 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -4403,6 +4541,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
@@ -5560,8 +5701,6 @@ snapshots:
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
 
-  '@electric-sql/pglite@0.2.17': {}
-
   '@electric-sql/pglite@0.4.5': {}
 
   '@emnapi/runtime@1.9.1':
@@ -5868,6 +6007,8 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.5':
     optional: true
+
+  '@ioredis/commands@1.5.1': {}
 
   '@isaacs/balanced-match@4.0.1': {}
 
@@ -7287,6 +7428,14 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
+  '@vitest/mocker@3.2.4(vite@7.2.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.2.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1)
+
   '@vitest/mocker@3.2.4(vite@7.2.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -7619,6 +7768,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cluster-key-slot@1.1.2: {}
+
   code-excerpt@4.0.0:
     dependencies:
       convert-to-spaces: 2.0.1
@@ -7705,6 +7856,8 @@ snapshots:
   deep-is@0.1.4: {}
 
   delayed-stream@1.0.0: {}
+
+  denque@2.1.0: {}
 
   detect-libc@2.1.2: {}
 
@@ -8239,6 +8392,20 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  ioredis@5.10.1:
+    dependencies:
+      '@ioredis/commands': 1.5.1
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3(supports-color@10.2.2)
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -8392,6 +8559,10 @@ snapshots:
       p-locate: 5.0.0
 
   lodash.camelcase@4.3.0: {}
+
+  lodash.defaults@4.2.0: {}
+
+  lodash.isarguments@3.1.0: {}
 
   lodash.merge@4.6.2: {}
 
@@ -8813,6 +8984,12 @@ snapshots:
 
   real-require@0.2.0: {}
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -9025,6 +9202,8 @@ snapshots:
       escape-string-regexp: 2.0.0
 
   stackback@0.0.2: {}
+
+  standard-as-callback@2.1.0: {}
 
   std-env@3.9.0: {}
 
@@ -9349,7 +9528,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.2.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(vite@7.2.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - packages/*
   - apps/*
+  - examples/*
   - e2e
 
 ignoredBuiltDependencies:


### PR DESCRIPTION
## Summary

- Add PGlite as an in-process destination backend (file://, memory:// URLs)
- Split destination-postgres client into separate `client-pg.ts` and `client-pglite.ts` files with shared `ManagedClient` interface
- Add `browser-sync` example app: React + Vite that runs the full sync engine in-browser with PGlite at `memory://` and live WebSocket updates
- Gate PGlite behind `allow_experimental_pglite` config flag
- CI: run on `dev` branch, only tag Docker `latest` on `main`

## Test plan

- [ ] `pnpm test` passes for destination-postgres (PGlite unit tests)
- [ ] `cd examples/browser-sync && pnpm dev` — app starts, enter Stripe key, sync runs in-browser
- [ ] CLI: `sync-engine sync --postgres-url memory:// ...` creates PGlite instance and syncs

🤖 Generated with [Claude Code](https://claude.com/claude-code)