### PR TITLE
fix: accept string request field in stripeEventSchema

### DIFF
--- a/packages/source-stripe/src/spec.test.ts
+++ b/packages/source-stripe/src/spec.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { z } from 'zod'
-import spec, { configSchema, streamStateSpec } from './spec.js'
+import spec, { configSchema, stripeEventSchema, streamStateSpec } from './spec.js'
 import { BUNDLED_API_VERSION, SUPPORTED_API_VERSIONS } from '@stripe/sync-openapi'
 
 describe('configSchema api_version field', () => {
@@ -68,5 +68,52 @@ describe('streamStateSpec JSON Schema round-trip', () => {
       ],
     }
     expect(zodFromJson.safeParse(stateInProgress).success).toBe(true)
+  })
+})
+
+describe('stripeEventSchema', () => {
+  it('accepts request as a plain string (older API versions)', () => {
+    const event = {
+      id: 'evt_test',
+      object: 'event',
+      api_version: '2020-08-27',
+      created: 1234567890,
+      data: { object: {} },
+      livemode: false,
+      pending_webhooks: 0,
+      request: 'req_xxxxx',
+      type: 'charge.created',
+    }
+    expect(stripeEventSchema.safeParse(event).success).toBe(true)
+  })
+
+  it('accepts request as an object (modern API versions)', () => {
+    const event = {
+      id: 'evt_test',
+      object: 'event',
+      api_version: '2020-08-27',
+      created: 1234567890,
+      data: { object: {} },
+      livemode: false,
+      pending_webhooks: 0,
+      request: { id: 'req_xxxxx', idempotency_key: null },
+      type: 'charge.created',
+    }
+    expect(stripeEventSchema.safeParse(event).success).toBe(true)
+  })
+
+  it('accepts request as null', () => {
+    const event = {
+      id: 'evt_test',
+      object: 'event',
+      api_version: '2020-08-27',
+      created: 1234567890,
+      data: { object: {} },
+      livemode: false,
+      pending_webhooks: 0,
+      request: null,
+      type: 'charge.created',
+    }
+    expect(stripeEventSchema.safeParse(event).success).toBe(true)
   })
 })

--- a/packages/source-stripe/src/spec.ts
+++ b/packages/source-stripe/src/spec.ts
@@ -113,10 +113,13 @@ export const stripeEventSchema = z.object({
       "Number of webhooks that haven't been successfully delivered (for example, to return a 20x response) to the URLs you specify."
     ),
   request: z
-    .object({
-      id: z.string().nullable(),
-      idempotency_key: z.string().nullable(),
-    })
+    .union([
+      z.string(),
+      z.object({
+        id: z.string().nullable(),
+        idempotency_key: z.string().nullable(),
+      }),
+    ])
     .nullable()
     .describe('Information on the API request that triggers the event.'),
   type: z


### PR DESCRIPTION

## Summary

<!-- What changed in plain language -->

- Older Stripe API versions send `request` as a plain string (e.g. "req_xxxxx") rather than an object. The schema rejected these, silently dropping webhook records. Accept both formats via z.union.


## How to test (optional)

<!-- Add steps only if useful -->

-

## Related

<!-- Link issue(s) if any -->

- Closes #

> Thanks for contributing ❤️
