### PR TITLE
fix(source-stripe): include canceled subscriptions in initial backfill

### DIFF
--- a/packages/openapi/__tests__/listFnResolver.test.ts
+++ b/packages/openapi/__tests__/listFnResolver.test.ts
@@ -230,6 +230,40 @@ describe('buildListFn / buildRetrieveFn', () => {
     expect(parsed.searchParams.get('created[lt]')).toBe('2025-01-02T00:00:00.000Z')
   })
 
+  it('appends extraQueryParams to v1 list calls', async () => {
+    const fetchMock = vi.fn(
+      async () => new Response(JSON.stringify({ data: [], has_more: false }), { status: 200 })
+    )
+    const list = buildListFn(
+      'sk_test_fake',
+      '/v1/subscriptions',
+      fetchMock,
+      '2024-06-20',
+      undefined,
+      { status: 'all' }
+    )
+    await list({ limit: 1 })
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(new URL(url).searchParams.get('status')).toBe('all')
+  })
+
+  it('appends extraQueryParams to v2 list calls', async () => {
+    const fetchMock = vi.fn(
+      async () => new Response(JSON.stringify({ data: [], next_page_url: null }), { status: 200 })
+    )
+    const list = buildListFn(
+      'sk_test_fake',
+      '/v2/core/events',
+      fetchMock,
+      '2024-06-20',
+      undefined,
+      { foo: 'bar' }
+    )
+    await list({ limit: 1 })
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(new URL(url).searchParams.get('foo')).toBe('bar')
+  })
+
   it('throws the Stripe error message for non-2xx retrieve responses', async () => {
     const fetchMock = vi.fn(
       async () =>

--- a/packages/openapi/listFnResolver.ts
+++ b/packages/openapi/listFnResolver.ts
@@ -148,7 +148,8 @@ export function buildListFn(
   apiPath: string,
   fetch: typeof globalThis.fetch,
   apiVersion: string,
-  baseUrl?: string
+  baseUrl?: string,
+  extraQueryParams?: Record<string, string>
 ): ListFn {
   const base = baseUrl ?? DEFAULT_STRIPE_API_BASE
 
@@ -161,6 +162,9 @@ export function buildListFn(
         for (const [op, val] of Object.entries(params.created)) {
           if (val != null) qs.set(`created[${op}]`, toV2CreatedParam(val))
         }
+      }
+      if (extraQueryParams) {
+        for (const [k, v] of Object.entries(extraQueryParams)) qs.set(k, v)
       }
 
       const headers = authHeaders(apiKey)
@@ -192,6 +196,9 @@ export function buildListFn(
       for (const [op, val] of Object.entries(params.created)) {
         if (val != null) qs.set(`created[${op}]`, String(val))
       }
+    }
+    if (extraQueryParams) {
+      for (const [k, v] of Object.entries(extraQueryParams)) qs.set(k, v)
     }
 
     const headers = authHeaders(apiKey)

--- a/packages/source-stripe/src/resourceRegistry.test.ts
+++ b/packages/source-stripe/src/resourceRegistry.test.ts
@@ -1,6 +1,74 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { OpenApiSpec } from '@stripe/sync-openapi'
 import { buildResourceRegistry } from './resourceRegistry.js'
+
+const subscriptionSpec: OpenApiSpec = {
+  openapi: '3.0.0',
+  paths: {
+    '/v1/subscriptions': {
+      get: {
+        parameters: [{ name: 'limit', in: 'query' }],
+        responses: {
+          '200': {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    object: { type: 'string', enum: ['list'] },
+                    data: {
+                      type: 'array',
+                      items: { $ref: '#/components/schemas/subscription' },
+                    },
+                    has_more: { type: 'boolean' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/v1/subscription_schedules': {
+      get: {
+        parameters: [{ name: 'limit', in: 'query' }],
+        responses: {
+          '200': {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    object: { type: 'string', enum: ['list'] },
+                    data: {
+                      type: 'array',
+                      items: { $ref: '#/components/schemas/subscription_schedule' },
+                    },
+                    has_more: { type: 'boolean' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      subscription: {
+        'x-resourceId': 'subscription',
+        type: 'object',
+        properties: { id: { type: 'string' } },
+      },
+      subscription_schedule: {
+        'x-resourceId': 'subscription_schedule',
+        type: 'object',
+        properties: { id: { type: 'string' } },
+      },
+    },
+  },
+}
 
 const v2CreatedSpec: OpenApiSpec = {
   openapi: '3.0.0',
@@ -94,5 +162,39 @@ describe('buildResourceRegistry', () => {
 
     expect(registry.v2_core_account?.supportsCreatedFilter).toBe(false)
     expect(registry.v2_core_event?.supportsCreatedFilter).toBe(true)
+  })
+
+  describe('list extra query params (issue #336)', () => {
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('passes status=all when listing subscriptions so canceled rows are included', async () => {
+      const fetchMock = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(
+          new Response(JSON.stringify({ data: [], has_more: false }), { status: 200 })
+        )
+
+      const registry = buildResourceRegistry(subscriptionSpec, 'sk_test_fake', '2026-03-25.dahlia')
+      await registry.subscription!.listFn!({ limit: 10 })
+
+      const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
+      expect(new URL(url).searchParams.get('status')).toBe('all')
+    })
+
+    it('passes scope=all when listing subscription schedules so canceled rows are included', async () => {
+      const fetchMock = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(
+          new Response(JSON.stringify({ data: [], has_more: false }), { status: 200 })
+        )
+
+      const registry = buildResourceRegistry(subscriptionSpec, 'sk_test_fake', '2026-03-25.dahlia')
+      await registry.subscription_schedule!.listFn!({ limit: 10 })
+
+      const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
+      expect(new URL(url).searchParams.get('scope')).toBe('all')
+    })
   })
 })

--- a/packages/source-stripe/src/resourceRegistry.ts
+++ b/packages/source-stripe/src/resourceRegistry.ts
@@ -108,6 +108,7 @@ export const EXCLUDED_TABLES = new Set([
  */
 const LIST_EXTRA_QUERY_PARAMS: Record<string, Record<string, string>> = {
   subscription: { status: 'all' },
+  subscription_schedule: { scope: 'all' },
 }
 
 export function buildResourceRegistry(

--- a/packages/source-stripe/src/resourceRegistry.ts
+++ b/packages/source-stripe/src/resourceRegistry.ts
@@ -100,6 +100,16 @@ export const EXCLUDED_TABLES = new Set([
   'billing_credit_balance_transaction',
 ])
 
+/**
+ * Per-table extra query parameters to pass on every list call.
+ * Some Stripe list endpoints filter results unless an explicit status is sent.
+ * For example, /v1/subscriptions excludes canceled subscriptions by default,
+ * so the initial backfill misses them entirely (issue #336).
+ */
+const LIST_EXTRA_QUERY_PARAMS: Record<string, Record<string, string>> = {
+  subscription: { status: 'all' },
+}
+
 export function buildResourceRegistry(
   spec: OpenApiSpec,
   apiKey: string,
@@ -130,7 +140,14 @@ export function buildResourceRegistry(
         supportsPagination: n.supportsPagination,
       }))
 
-    const rawListFn = buildListFn(apiKey, endpoint.apiPath, apiFetch, apiVersion, baseUrl)
+    const rawListFn = buildListFn(
+      apiKey,
+      endpoint.apiPath,
+      apiFetch,
+      apiVersion,
+      baseUrl,
+      LIST_EXTRA_QUERY_PARAMS[tableName]
+    )
     const rawRetrieveFn = buildRetrieveFn(apiKey, endpoint.apiPath, apiFetch, apiVersion, baseUrl)
 
     const config: ResourceConfig = {


### PR DESCRIPTION
## Summary

Add support for passing extra query parameters on list API calls to ensure canceled resources are included in syncs. Stripe's `/v1/subscriptions` and `/v1/subscription_schedules` endpoints exclude canceled items by default, causing the initial backfill to miss them entirely.

- Add `extraQueryParams` optional parameter to `buildListFn()` in `packages/openapi`
- Define `LIST_EXTRA_QUERY_PARAMS` mapping in `packages/source-stripe` to pass `status=all` for subscriptions and `scope=all` for subscription schedules
- Wire extra params through the resource registry when building list functions

## How to test

Added comprehensive unit tests:
- `packages/openapi/__tests__/listFnResolver.test.ts`: Two new tests verify extra query params are appended to both v1 and v2 list calls
- `packages/source-stripe/src/resourceRegistry.test.ts`: Two new tests mock fetch and verify the correct status/scope params are passed when listing subscriptions and subscription schedules

## Related

- Closes #336